### PR TITLE
LogMessage(To) functions with format args as a va_list argument

### DIFF
--- a/Client Logger/LoggerClient.h
+++ b/Client Logger/LoggerClient.h
@@ -115,6 +115,10 @@ extern void LogMessageCompatTo(Logger *logger, NSString *format, ...);
 extern void LogMessage(NSString *domain, int level, NSString *format, ...);
 extern void LogMessageTo(Logger *logger, NSString *domain, int level, NSString *format, ...);
 
+// Log a message. domain can be nil if default domain (versions with va_list format args instead of ...)
+extern void LogMessage_va(NSString *domain, int level, NSString *format, va_list args);
+extern void LogMessageTo_va(Logger *logger, NSString *domain, int level, NSString *format, va_list args);
+
 // Send binary data to remote logger
 extern void LogData(NSString *domain, int level, NSData *data);
 extern void LogDataTo(Logger *logger, NSString *domain, int level, NSData *data);

--- a/Client Logger/LoggerClient.m
+++ b/Client Logger/LoggerClient.m
@@ -991,12 +991,22 @@ void LogMessageTo(Logger *logger, NSString *domain, int level, NSString *format,
 	va_end(args);
 }
 
+void LogMessageTo_va(Logger *logger, NSString *domain, int level, NSString *format, va_list args)
+{
+	LogMessageTo_internal(logger, domain, level, format, args);
+}
+
 void LogMessage(NSString *domain, int level, NSString *format, ...)
 {
 	va_list args;
 	va_start(args, format);
 	LogMessageTo_internal(sDefaultLogger, domain, level, format, args);
 	va_end(args);
+}
+
+void LogMessage_va(NSString *domain, int level, NSString *format, va_list args)
+{
+	LogMessageTo_internal(sDefaultLogger, domain, level, format, args);
 }
 
 void LogData(NSString *domain, int level, NSData *data)


### PR DESCRIPTION
Dear Florent,
it would be nice if you could integrate these changes into the main repository.
Best regards, Arne
PS: I'm trying to integrate your NSLogger client as a back-end for LibComponentLogging.
