### PR TITLE
Minor UI fix in Desktop View filter rules editor

### DIFF
--- a/Desktop Viewer/Classes/LoggerWindowController.m
+++ b/Desktop Viewer/Classes/LoggerWindowController.m
@@ -1322,6 +1322,7 @@ didReceiveMessages:(NSArray *)theMessages
 						  [NSCompoundPredicate andPredicateWithSubpredicates:[NSArray array]], @"predicate",
 						  nil];
 	[self openFilterEditSheet:dict];
+	[filterEditor addRow:self];
 }
 
 - (IBAction)startEditingFilter:(id)sender
@@ -1332,6 +1333,7 @@ didReceiveMessages:(NSArray *)theMessages
 	if (dict == nil || [[dict objectForKey:@"uid"] integerValue] == 1)
 		return;
 	[self openFilterEditSheet:dict];
+	
 }
 
 - (IBAction)cancelFilterEdition:(id)sender


### PR DESCRIPTION
Minor UI fix for the Desktop Viewer: when creating a new filter, a default condition row is already added to the rules editor, to save the previously required click on the Add button.
