### PR TITLE
Preserve messages across runs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.perspectivev3
 *.mode1v3
 *.mode2v3
+*.xcuserdatad

--- a/Desktop Viewer/Classes/LoggerAppDelegate.m
+++ b/Desktop Viewer/Classes/LoggerAppDelegate.m
@@ -272,6 +272,7 @@ NSString * const kPref_ApplicationFilterSet = @"appFilterSet";
 				if ([doc isKindOfClass:[LoggerDocument class]] && doc.attachedConnection == c)
 				{
 					// recycle this document window, bring it to front
+                    [aConnection addMessagesFromPreviousRun:c];
 					aConnection.reconnectionCount = c.reconnectionCount + 1;
 					doc.attachedConnection = aConnection;
 					return;

--- a/Desktop Viewer/Classes/LoggerConnection.h
+++ b/Desktop Viewer/Classes/LoggerConnection.h
@@ -106,6 +106,7 @@
 - (NSString *)clientDescription;
 
 - (BOOL)isNewRunOfClient:(LoggerConnection *)aConnection;
+- (void)addMessagesFromPreviousRun:(LoggerConnection*)aConnection;
 
 @end
 


### PR DESCRIPTION
These little changes will preserve messages across different runs of the same app, when the Desktop Viewer decides that it reuses an window.

(Also it ignores the user data files Xcode 4 creates)
