### PR TITLE
Client Logger: Support ARC (by removing autorelease pools and bridging ca

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -385,7 +385,6 @@ static void LoggerDbg(CFStringRef format, ...)
 	// (what do you think, that we use the Logger to debug itself ??)
 	if (format != NULL)
 	{
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 		va_list	args;	
 		va_start(args, format);
 		CFStringRef s = CFStringCreateWithFormatAndArguments(NULL, NULL, (CFStringRef)format, args);
@@ -395,7 +394,6 @@ static void LoggerDbg(CFStringRef format, ...)
 			CFShow(s);
 			CFRelease(s);
 		}
-		[pool drain];
 	}
 }
 
@@ -1545,7 +1543,6 @@ static void LoggerMessageAddTimestampAndThreadID(CFMutableDataRef encoder)
 	// and for which Cocoa's multithreading has not been activated. We test for this case.
 	if ([NSThread isMultiThreaded] || [NSThread isMainThread])
 	{
-		NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 		NSThread *thread = [NSThread currentThread];
 		NSString *name = [thread name];
 		if (![name length])
@@ -1566,10 +1563,9 @@ static void LoggerMessageAddTimestampAndThreadID(CFMutableDataRef encoder)
 		}
 		if (name != nil)
 		{
-			LoggerMessageAddString(encoder, (CFStringRef)name, PART_KEY_THREAD_ID);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)name, PART_KEY_THREAD_ID);
 			hasThreadName = YES;
 		}
-		[pool drain];
 	}
 #endif
 	if (!hasThreadName)
@@ -1771,13 +1767,11 @@ static void	LoggerPushClientInfoToFrontOfQueue(Logger *logger)
 #if TARGET_OS_IPHONE && ALLOW_COCOA_USE
 		if ([NSThread isMultiThreaded] || [NSThread isMainThread])
 		{
-			NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 			UIDevice *device = [UIDevice currentDevice];
-			LoggerMessageAddString(encoder, (CFStringRef)device.uniqueIdentifier, PART_KEY_UNIQUEID);
-			LoggerMessageAddString(encoder, (CFStringRef)device.systemVersion, PART_KEY_OS_VERSION);
-			LoggerMessageAddString(encoder, (CFStringRef)device.systemName, PART_KEY_OS_NAME);
-			LoggerMessageAddString(encoder, (CFStringRef)device.model, PART_KEY_CLIENT_MODEL);
-			[pool release];
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)device.uniqueIdentifier, PART_KEY_UNIQUEID);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)device.systemVersion, PART_KEY_OS_VERSION);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)device.systemName, PART_KEY_OS_NAME);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)device.model, PART_KEY_CLIENT_MODEL);
 		}
 #elif TARGET_OS_MAC
 		SInt32 versionMajor, versionMinor, versionFix;
@@ -1883,7 +1877,7 @@ static void LogMessageTo_internal(Logger *logger,
 		LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
 		LoggerMessageAddInt32(encoder, seq, PART_KEY_MESSAGE_SEQ);
 		if (domain != nil && [domain length])
-			LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)domain, PART_KEY_TAG);
 		if (level)
 			LoggerMessageAddInt32(encoder, level, PART_KEY_LEVEL);
 		if (filename != NULL)
@@ -1898,8 +1892,7 @@ static void LogMessageTo_internal(Logger *logger,
 		NSString *msgString = [[NSString alloc] initWithFormat:format arguments:args];
 		if (msgString != nil)
 		{
-			LoggerMessageAddString(encoder, (CFStringRef)msgString, PART_KEY_MESSAGE);
-			[msgString release];
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)msgString, PART_KEY_MESSAGE);
 		}
 #else
 		CFStringRef msgString = CFStringCreateWithFormatAndArguments(NULL, NULL, (CFStringRef)format, args);
@@ -1945,7 +1938,7 @@ static void LogImageTo_internal(Logger *logger,
 		LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
 		LoggerMessageAddInt32(encoder, seq, PART_KEY_MESSAGE_SEQ);
 		if (domain != nil && [domain length])
-			LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)domain, PART_KEY_TAG);
 		if (level)
 			LoggerMessageAddInt32(encoder, level, PART_KEY_LEVEL);
 		if (width && height)
@@ -1959,7 +1952,7 @@ static void LogImageTo_internal(Logger *logger,
 			LoggerMessageAddInt32(encoder, lineNumber, PART_KEY_LINENUMBER);
 		if (functionName != NULL)
 			LoggerMessageAddCString(encoder, functionName, PART_KEY_FUNCTIONNAME);
-		LoggerMessageAddData(encoder, (CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_IMAGE);
+		LoggerMessageAddData(encoder, (__bridge CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_IMAGE);
 
 		LoggerPushMessageToQueue(logger, encoder);
 		CFRelease(encoder);
@@ -1993,7 +1986,7 @@ static void LogDataTo_internal(Logger *logger,
 		LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
 		LoggerMessageAddInt32(encoder, seq, PART_KEY_MESSAGE_SEQ);
 		if (domain != nil && [domain length])
-			LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)domain, PART_KEY_TAG);
 		if (level)
 			LoggerMessageAddInt32(encoder, level, PART_KEY_LEVEL);
 		if (filename != NULL)
@@ -2002,7 +1995,7 @@ static void LogDataTo_internal(Logger *logger,
 			LoggerMessageAddInt32(encoder, lineNumber, PART_KEY_LINENUMBER);
 		if (functionName != NULL)
 			LoggerMessageAddCString(encoder, functionName, PART_KEY_FUNCTIONNAME);
-		LoggerMessageAddData(encoder, (CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_BINARY);
+		LoggerMessageAddData(encoder, (__bridge CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_BINARY);
 		
 		LoggerPushMessageToQueue(logger, encoder);
 		CFRelease(encoder);
@@ -2034,7 +2027,7 @@ static void LogStartBlockTo_internal(Logger *logger, NSString *format, va_list a
 		CFStringRef msgString = NULL;
 		if (format != nil)
 		{
-			msgString = CFStringCreateWithFormatAndArguments(NULL, NULL, (CFStringRef)format, args);
+			msgString = CFStringCreateWithFormatAndArguments(NULL, NULL, (__bridge CFStringRef)format, args);
 			if (msgString != NULL)
 			{
 				LoggerMessageAddString(encoder, msgString, PART_KEY_MESSAGE);
@@ -2227,7 +2220,7 @@ void LogMarkerTo(Logger *logger, NSString *text)
 		}
 		else
 		{
-			LoggerMessageAddString(encoder, (CFStringRef)text, PART_KEY_MESSAGE);
+			LoggerMessageAddString(encoder, (__bridge CFStringRef)text, PART_KEY_MESSAGE);
 		}
 		LoggerMessageAddInt32(encoder, seq, PART_KEY_MESSAGE_SEQ);
 		LoggerPushMessageToQueue(logger, encoder);


### PR DESCRIPTION
Client Logger: Support ARC (by removing autorelease pools and bridging casts

DON'T just pull this. It's gonna leak in non-ARC mode and I'm not even sure if it works at all without ARC due to the __bridge cast type.

There is __has_feature(objc_arc), but clang would keep complaining if I just if'ed the parts in question. Anyway, you can refer people to this commit if they ask for ARC.
