### PR TITLE
Fixed Crash when NSData to log is nil

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -1693,14 +1693,16 @@ static void LoggerMessageAddString(CFMutableDataRef data, CFStringRef aString, i
 
 static void LoggerMessageAddData(CFMutableDataRef data, CFDataRef theData, int key, int partType)
 {
-	uint8_t keyAndType[2] = {(uint8_t)key, (uint8_t)partType};
-	CFIndex dataLength = CFDataGetLength(theData);
-	uint32_t partSize = htonl(dataLength);
-	CFDataAppendBytes(data, (const UInt8 *)&keyAndType, 2);
-	CFDataAppendBytes(data, (const UInt8 *)&partSize, 4);
-	if (partSize)
-		CFDataAppendBytes(data, CFDataGetBytePtr(theData), dataLength);
-	LoggerMessageUpdateDataHeader(data);
+	if ( theData != nil ){
+		uint8_t keyAndType[2] = {(uint8_t)key, (uint8_t)partType};
+		CFIndex dataLength = CFDataGetLength(theData);
+		uint32_t partSize = htonl(dataLength);
+		CFDataAppendBytes(data, (const UInt8 *)&keyAndType, 2);
+		CFDataAppendBytes(data, (const UInt8 *)&partSize, 4);
+		if (partSize)
+			CFDataAppendBytes(data, CFDataGetBytePtr(theData), dataLength);
+		LoggerMessageUpdateDataHeader(data);
+	}
 }
 
 static uint32_t LoggerMessageGetSeq(CFDataRef message)


### PR DESCRIPTION
This is just mildly annoying, but I don't want to check the data before i pass it to the logging, so I added a little check in the LoggerMessageAddData method.. works fine now. 
