### PR TITLE
Make sure to honor BufferLogsUntilConnection

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -793,6 +793,23 @@ static void LoggerWriteMoreData(Logger *logger)
 		{
 			LoggerFlushQueueToBufferStream(logger, NO);
 		}
+        else if (!(logger->options & kLoggerOption_BufferLogsUntilConnection))
+        {
+            /* No client connected
+             * User don't want to log to console
+             * User don't want to log to file
+             * and user don't want us to buffer it in memory
+             * So let's just sack the whole queue
+             */
+			pthread_mutex_lock(&logger->logQueueMutex);
+			while (CFArrayGetCount(logger->logQueue))
+			{
+				CFArrayRemoveValueAtIndex(logger->logQueue, 0);
+			}
+			pthread_mutex_unlock(&logger->logQueueMutex);
+			pthread_cond_broadcast(&logger->logQueueEmpty);
+        }
+
 		return;
 	}
 	


### PR DESCRIPTION
Currently NSLogger will buffer in memory if you don't set log to console or set a buffer log file. This patch is throwing away the queue if kLoggerOption_BufferUntilConnection is not set.

This bug made me run around in circles looking for memory leaks for a while :-)
