### PR TITLE
Fix for a crash when quitting NSLogger Viewer while some log windows are still opened

### DIFF
--- a/Desktop Viewer/Classes/LoggerWindowController.m
+++ b/Desktop Viewer/Classes/LoggerWindowController.m
@@ -103,7 +103,15 @@ static NSArray *sXcodeFileExtensions = nil;
 	[markerCell release];
 	if (lastTilingGroup)
 		dispatch_release(lastTilingGroup);
-	[super dealloc];
+
+    logTable.delegate = nil;
+    logTable.dataSource = nil;
+	filterSetsTable.delegate = nil;
+    filterSetsTable.dataSource = nil;
+	filterTable.delegate = nil;
+    filterTable.dataSource = nil;
+    
+    [super dealloc];
 }
 
 - (NSUndoManager *)undoManager


### PR DESCRIPTION
NSTableViews that have LoggerWindowController as data source try to access it when the app is quitting but LoggerWindowController has already been dealloced.

This patch fixes this issue, however I wonder if it is not a deallocation chain issue and then this is maybe not the best solution.
