### PR TITLE
Avoid build warnings by covering all enum cases

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -1567,6 +1567,10 @@ static void LoggerWriteStreamCallback(CFWriteStreamRef ws, CFStreamEventType eve
 			else
 				LoggerTryConnect(logger);
 			break;
+        // avoid warnings when building; cover all enum cases.
+        case kCFStreamEventNone:
+        case kCFStreamEventHasBytesAvailable:
+            break;
 	}
 }
 


### PR DESCRIPTION
This just hushes up an Xcode build warning when adding the NSLogger client to an iOS project. By explicitly handling all enums in the case the warning is quieted. Using default: would do the same thing. The enum has been available since iOS 2 so should present no problems for anyone.
