### PR TITLE
Create the logqueue as unlimited CFArray, as it may overflow

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -223,7 +223,7 @@ Logger *LoggerInit(void)
 	Logger *logger = (Logger *)malloc(sizeof(Logger));
 	bzero(logger, sizeof(Logger));
 
-	logger->logQueue = CFArrayCreateMutable(NULL, 32, &kCFTypeArrayCallBacks);
+	logger->logQueue = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
 	pthread_mutex_init(&logger->logQueueMutex, NULL);
 	pthread_cond_init(&logger->logQueueEmpty, NULL);
 


### PR DESCRIPTION
This happens mostly if you log a lot of things and the network connection can not keep up.

Easy to reproduce on an iPad:
- "Network Link Conditioner" using the "Edge" profile and turned on.
- Log a lot of messages (more than 32 exactly, before the Logger has the time to send it to the logger host)
- Crash in `LoggerMessageGetSeq` with bogus values for `partCount` as somewhere the array overflowed (part-counts of 8000 and higher were seen here)

Alternatively one could limit the queue to 32 items (to avoid eating too much memory) and block on logging the 33rd until the log has been written/transmitted to the disk/host. But for me an unlimited queue seems to be not so bad.
