### PR TITLE
Fix for EXC_BAD_ACCESS

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -2295,7 +2295,13 @@ static void LogMessageTo_internal(Logger *logger,
 
 #if ALLOW_COCOA_USE
             // Go though NSString to avoid low-level logging of CF datastructures (i.e. too detailed NSDictionary, etc)
-            NSString *msgString = [[NSString alloc] initWithFormat:format arguments:args];
+            NSString *msgString = nil;
+            if (*args == '\0')
+            {
+                msgString = format;
+            } else {
+                msgString = [[NSString alloc] initWithFormat:format arguments:args];
+            }
             if (msgString != nil)
             {
                 LoggerMessageAddString(encoder, (CAST_TO_CFSTRING)msgString, PART_KEY_MESSAGE);


### PR DESCRIPTION
Hi Flaurent,

we've seen a reproducible crash in LogMessageTo_internal which this pull request is hoping to fix. I'm not entirely sure if this is the best way to fix the issue but it does solve our problem.

Some debug details below.

```
(lldb) bt
* thread #8: tid = 0x2703, 0x0318eb60 libsystem_sim_c.dylib`strlen + 16, stop reason = EXC_BAD_ACCESS (code=2, address=0x270)
    frame #0: 0x0318eb60 libsystem_sim_c.dylib`strlen + 16
    frame #1: 0x02cce0c7 CoreFoundation`__CFStringAppendFormatCore + 13623
    frame #2: 0x02d1413c CoreFoundation`_CFStringCreateWithFormatAndArgumentsAux + 108
    frame #3: 0x006fe690 Foundation`-[NSPlaceholderString initWithFormat:locale:arguments:] + 143
    frame #4: 0x00721285 Foundation`-[NSString initWithFormat:arguments:] + 55
    frame #5: 0x0039a321 WE7 Music`LogMessageTo_internal(logger=0x0a3d4b50, filename=0x00000000, lineNumber=0, functionName=0x00000000, domain=0x004e9128, level=1, format=0x14b31000, args=0xb0364a80) + 1217 at LoggerClient.m:2309
    frame #6: 0x0039a5e0 WE7 Music`LogMessageTo(logger=0x0a3d4b50, domain=0x004e9128, level=1, format=0x14b31000) + 144 at LoggerClient.m:2486
    frame #7: 0x003a1ef4 WE7 Music`LoggerLogFromFile(fd=10) + 740 at LoggerClient.m:1008
    frame #8: 0x003a1b1d WE7 Music`LoggerConsoleGrabThread(context=0x00000000) + 1005 at LoggerClient.m:1052
    frame #9: 0x987285b7 libsystem_c.dylib`_pthread_start + 344
(lldb) p args
(va_list) $0 = 0xb0364a80
(lldb) p *args
(char) $1 = '\0'
```
