### PR TITLE
Made "⌥ + double click" Open Quickly

### DIFF
--- a/Desktop Viewer/xedReplacement.sh
+++ b/Desktop Viewer/xedReplacement.sh
@@ -8,19 +8,15 @@ else
     file=$1
 fi
 
+echo -n "${file##*/}:$line" | pbcopy
+
 osascript &>/dev/null <<EOF
     tell application "Xcode"
-        open "$file"
         activate
         tell application "System Events"
-            tell process "Xcode"
-                keystroke "l" using command down
-                repeat until window "Jump" exists
-                end repeat
-                click text field 1 of window "Jump"
-                set value of text field 1 of window "Jump" to "$line"
-                keystroke return
-            end tell
+            keystroke "o" using {command down, shift down}
+            keystroke "v" using {command down}
+            keystroke return
         end tell
     end tell
 EOF


### PR DESCRIPTION
While this is admittedly hacky, I noticed that the `open "$file"` command was seriously slowing down the xedReplacement.sh script... so I got rid of it.

I've always got the project that I'm logging open, and the increased speed I get by doing this is pretty huge.

I also tweaked the script a bit more to utilize **Open Quickly** instead of **Jump** to get to the exact line in the source file via _NSLogger_ even faster.
