### PR TITLE
Made default double click behavior open file:line

### DIFF
--- a/Desktop Viewer/Classes/LoggerWindowController.m
+++ b/Desktop Viewer/Classes/LoggerWindowController.m
@@ -786,10 +786,15 @@ static NSArray *sXcodeFileExtensions = nil;
 
 - (void)logCellDoubleClicked:(id)sender
 {
-	// Added in v1.1: alt-double click opens the source file if it was defined in the log
-	// and the file is found
+	// double click opens the source file if it was defined in the log
+	// and the file is found (using alt can mess with the results of the AppleScript)
 	NSEvent *event = [NSApp currentEvent];
-	if ([event clickCount] > 1 && ([NSEvent modifierFlags] & NSAlternateKeyMask) != 0)
+    // alt + double click opens the detail view
+    if ([event clickCount] > 1 && ([NSEvent modifierFlags] & NSAlternateKeyMask) != 0)
+    {
+        [self openDetailsWindow:sender];
+    }
+    else if ([event clickCount] > 1)
 	{
 		NSInteger row = [logTable selectedRow];
 		if (row >= 0 && row < [displayedMessages count])
@@ -821,7 +826,7 @@ static NSArray *sXcodeFileExtensions = nil;
 					if (useXcode)
 					{                        
                         [self xedFile:filename 
-                                 line:[NSString stringWithFormat:@"%d", MAX(0, msg.lineNumber) + 1]];
+                                 line:[NSString stringWithFormat:@"%d", MAX(0, msg.lineNumber)]];
 					}
 					else
 					{
@@ -832,8 +837,14 @@ static NSArray *sXcodeFileExtensions = nil;
 		}
 		return;
 	}
-	[self openDetailsWindow:sender];
 }
+
+#pragma mark Target Action
+
+- (IBAction)performFindPanelAction:(id)sender {
+    [self.window makeFirstResponder:quickFilterTextField];
+}
+
 
 // -----------------------------------------------------------------------------
 #pragma mark -


### PR DESCRIPTION
This commit flips the normal doble click behavior with the "⌥ + double click" behavior.

The reason for this is that the ⌥ key can interfere with the AppleScript in `xedReplacement.sh`, leading to some of the issues discussed at https://github.com/fpillet/NSLogger/issues/30

Also, added ⌘+F shortcut for faster access to filtering.
