### PR TITLE
Add NSLOGGER_WAS_HERE as preprocessor macro for Cocoapods

### DIFF
--- a/NSLogger.podspec
+++ b/NSLogger.podspec
@@ -15,4 +15,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Client Logger/iOS/*.{h,m}'
   s.ios.frameworks   = 'CFNetwork', 'SystemConfiguration'
   s.osx.frameworks = 'CFNetwork', 'SystemConfiguration', 'CoreServices'
+
+  s.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => '$(inherited) NSLOGGER_WAS_HERE=1' }
 end


### PR DESCRIPTION
When using CocoaPods, NSLOGGER_WAS_HERE is included
as preprocessor macro in the project settings. This allows
other pods to recognize NSLogger and react to its
presence.
