### PR TITLE
Double-click behavior and multiple windows fixes

### DIFF
--- a/Desktop Viewer/Classes/LoggerWindowController.m
+++ b/Desktop Viewer/Classes/LoggerWindowController.m
@@ -809,11 +809,12 @@ static NSArray *sXcodeFileExtensions = nil;
 	[detailsWindowController showWindow:self];
 }
 
-- (void)xedFile:(NSString *)path line:(NSString *)line { 
+- (void)xedFile:(NSString *)path line:(NSString *)line client:(NSString *)client {
     id args = [NSArray arrayWithObjects:
                @"-l",
                line,
                path,
+               client,
                nil];
     // NSLog(@"Args %@", args);
     [NSTask launchedTaskWithLaunchPath:[[NSBundle mainBundle] pathForResource:@"xedReplacement.sh" ofType:nil]
@@ -822,11 +823,16 @@ static NSArray *sXcodeFileExtensions = nil;
 
 - (void)logCellDoubleClicked:(id)sender
 {
-	// Added in v1.1: alt-double click opens the source file if it was defined in the log
-	// and the file is found
+	// double click opens the source file if it was defined in the log
+	// and the file is found (using alt can mess with the results of the AppleScript)
+    // alt + double click opens the detail view
 	NSEvent *event = [NSApp currentEvent];
-	if ([event clickCount] > 1 && ([NSEvent modifierFlags] & NSAlternateKeyMask) != 0)
-	{
+    if ([event clickCount] > 1 && ([NSEvent modifierFlags] & NSAlternateKeyMask) != 0)
+    {
+        [self openDetailsWindow:sender];
+    }
+    else if ([event clickCount] > 1)
+    {
 		NSInteger row = [logTable selectedRow];
 		if (row >= 0 && row < [displayedMessages count])
 		{
@@ -857,7 +863,8 @@ static NSArray *sXcodeFileExtensions = nil;
 					if (useXcode)
 					{                        
                         [self xedFile:filename 
-                                 line:[NSString stringWithFormat:@"%d", MAX(0, msg.lineNumber) + 1]];
+                                 line:[NSString stringWithFormat:@"%d", MAX(0, msg.lineNumber)]
+                               client:[attachedConnection clientName]];
 					}
 					else
 					{
@@ -868,7 +875,6 @@ static NSArray *sXcodeFileExtensions = nil;
 		}
 		return;
 	}
-	[self openDetailsWindow:sender];
 }
 
 // -----------------------------------------------------------------------------

--- a/Desktop Viewer/NSLogger.xcodeproj/project.pbxproj
+++ b/Desktop Viewer/NSLogger.xcodeproj/project.pbxproj
@@ -616,7 +616,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Don't Code Sign";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -637,7 +637,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Don't Code Sign";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -668,9 +668,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = NSLogger_Prefix.pch;
-				HEADER_SEARCH_PATHS = (
-					"\"Third Party/BWToolkit\"",
-				);
+				HEADER_SEARCH_PATHS = "\"Third Party/BWToolkit\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = NSLogger;
@@ -691,9 +689,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = NSLogger_Prefix.pch;
-				HEADER_SEARCH_PATHS = (
-					"\"Third Party/BWToolkit\"",
-				);
+				HEADER_SEARCH_PATHS = "\"Third Party/BWToolkit\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = NSLogger;
@@ -705,6 +701,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
@@ -720,6 +717,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;

--- a/Desktop Viewer/xedReplacement.sh
+++ b/Desktop Viewer/xedReplacement.sh
@@ -3,24 +3,27 @@
 if [ "$1" = "-l" ] || [ "$1" = "--line" ] ; then
     line=$2
     file=$3
+    client=$4
 else
     line=1
     file=$1
 fi
 
+echo -n "${file##*/}:$line" | pbcopy
+
 osascript &>/dev/null <<EOF
-    tell application "Xcode"
-        open "$file"
-        activate
-        tell application "System Events"
-            tell process "Xcode"
-                keystroke "l" using command down
-                repeat until window "Jump" exists
-                end repeat
-                click text field 1 of window "Jump"
-                set value of text field 1 of window "Jump" to "$line"
+tell application "System Events"
+	set allWindowsName to name of window of processes whose name is "Xcode"
+	repeat with theWindowName in item 1 of allWindowsName
+		if theWindowName contains "$client" then
+			tell process "Xcode"
+				set frontmost to true
+				perform action "AXRaise" of (windows whose title is theWindowName)
+				keystroke "o" using {command down} -- default is actually keystroke "o" using {command down, shift down}
+                keystroke "v" using {command down}
                 keystroke return
-            end tell
-        end tell
-    end tell
+			end tell
+		end if
+	end repeat
+end tell
 EOF


### PR DESCRIPTION
Instead of opening the "detail view", double-clicking on a log item now immediately takes you straight to the line in the source code where the log statement was made. Using double-click + alt opens the "detail view" instead, since this is a less-likely scenario.

Also, tweaked the AppleScript to make it faster (the call to `open "$file"` was _especially_ affecting responsiveness). In case there are multiple NSLogger debugging sessions going on, as well as multiple Xcode project windows open, the changes to xedReplacement.sh bring the proper window to be the frontmost while still avoiding the slowness of the `open` command in the bash script.
