### PR TITLE
Fix build warnings for iOS 7 SDK

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -1010,7 +1010,7 @@ static void LoggerWriteMoreData(Logger *logger)
 		}
 		
 		pthread_mutex_lock(&logger->logQueueMutex);
-		int remainingMsgs = CFArrayGetCount(logger->logQueue);
+		CFIndex remainingMsgs = CFArrayGetCount(logger->logQueue);
 		pthread_mutex_unlock(&logger->logQueueMutex);
 		if (remainingMsgs == 0)
 			pthread_cond_broadcast(&logger->logQueueEmpty);
@@ -1978,7 +1978,7 @@ static uint8_t *LoggerMessagePrepareForPart(CFMutableDataRef encoder, uint32_t r
 	// Ensure a data block has the required storage capacity, update the total size and part count
 	// then return a pointer for fast storage of the data
 	uint8_t *p = CFDataGetMutableBytePtr(encoder);
-	uint32_t size = CFDataGetLength(encoder);
+	CFIndex size = CFDataGetLength(encoder);
 	uint32_t oldSize = ntohl(*(uint32_t *)p);
 	uint32_t newSize = oldSize + requiredExtraBytes;
 	if ((newSize + 4) > size)


### PR DESCRIPTION
When building on Xcode 5 with the iOS 7 SDK, we need to have the correct size for integers in 64-bit mode.

This does not fix the warnings about updating to the latest Xcode and SDK, it just allows you to build, which is handy when you have warnings as errors...
