### PR TITLE
import LoggerClient.h before the macro ALLOW_COCOA_USE is used.

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -37,6 +37,10 @@
 #import <sys/time.h>
 #import <arpa/inet.h>
 #import <stdlib.h>
+
+#import "LoggerClient.h"
+#import "LoggerCommon.h"
+
 #if !TARGET_OS_IPHONE
 	#import <sys/types.h>
 	#import <sys/sysctl.h>
@@ -46,9 +50,6 @@
 	#import <UIKit/UIKit.h>
 #endif
 #import <fcntl.h>
-
-#import "LoggerClient.h"
-#import "LoggerCommon.h"
 
 /* --------------------------------------------------------------------------------
  * IMPLEMENTATION NOTES:


### PR DESCRIPTION
LoggerClient.h is where the macro ALLOW_COCOA_USE is defined. Re-order #import statements for LoggerClient.m so that LoggerClient.h is included before ALLOW_COCOA_USE is tested.
