### PR TITLE
Ensure all embedded frameworks are signed for Mavericks.

### DIFF
--- a/Desktop Viewer/NSLogger.xcodeproj/project.pbxproj
+++ b/Desktop Viewer/NSLogger.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 				8D11072E0486CEB800E47090 /* Frameworks */,
 				3D4EA21C0F385B6100DF81E6 /* CopyFiles */,
 				3DE8CE8712AE4A74005C83D0 /* CopyFiles */,
+				D4F414041829766D00E88648 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -569,6 +570,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/bash\nif [ -z \"$CODE_SIGN_IDENTITY\" ] || [ \"$CODE_SIGN_IDENTITY\" == \"Don't Code Sign\" ] ; then\n    osascript -e \"tell application \\\"Xcode\\\"\n            display alert \\\"Your build is not code signed\\\" message \\\"Signing your build will prevent an issue with SSL connections failing the first time and requiring a NSLogger restart (or even failing altogether on OS X 10.7).\\n\\nTo sign your build, open the NSLogger target and select your developer certificate in the Code Signing Identity build setting.\\n\\nFurther instructions can be found in the README.txt file in the project folder.\\\"\n            end tell\"\nfi\n";
+		};
+		D4F414041829766D00E88648 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /usr/bin/python;
+			shellScript = "# Extremely ugly little Python script to ensure all frameworks under a directory are signed.\n# Use as part of a shell run phase.\n\nimport subprocess\nimport os\n\nlocation = os.environ['BUILT_PRODUCTS_DIR'] + \"/\" + os.environ['FRAMEWORKS_FOLDER_PATH']\n\n# Retrieve any frameworks\n\n\nfindoutput = subprocess.check_output('find \\\"' + location + '\\\" -name *.framework -print', shell=True)\n\nfindlist = filter(None,findoutput.split('\\n'))\nfor line in reversed(findlist):\n    framework = line.rstrip()\n    frameworkname = os.path.basename(os.path.normpath(framework))\n    checkline = subprocess.check_output('codesign -v \\\"' + framework + '\\\" ; exit 0', shell=True, stderr=subprocess.STDOUT)\n    if \"code object is not signed at all\" in checkline:\n        print \"Signing \" + frameworkname + \"...\"\n        signcmd = subprocess.check_output('codesign --verbose --sign \\\"' + os.environ['CODE_SIGN_IDENTITY'] + '\\\" \\\"' + framework + '\\\"', shell=True, stderr=subprocess.STDOUT)\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -688,9 +702,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = NSLogger_Prefix.pch;
-				HEADER_SEARCH_PATHS = (
-					"\"Third Party/BWToolkit\"",
-				);
+				HEADER_SEARCH_PATHS = "\"Third Party/BWToolkit\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = NSLogger;
@@ -711,9 +723,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = NSLogger_Prefix.pch;
-				HEADER_SEARCH_PATHS = (
-					"\"Third Party/BWToolkit\"",
-				);
+				HEADER_SEARCH_PATHS = "\"Third Party/BWToolkit\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = NSLogger;


### PR DESCRIPTION
This is just a simple modification to the NSLogger desktop client xcodeproj.  In Mavericks, if any embedded framework is unsigned the app will be labeled 'corrupt' and the user offered a chance to put it into the trash.  In Xcode 5.0.1, if you attempt to code sign an application which has unsigned frameworks, the build step fails.  Since BWToolkitFramework, HockeyApp and HockeyAppSDK's built-in CrashReporter framework are all unsigned, NSLogger fails to build.

This is resolved by adding a new build "run shell" phase, which executes a simple (if somewhat ugly) Python script to walk any embedded frameworks in the built products directory (including frameworks in other frameworks, to catch CrashReporter in HockeyAppSDK), finding those that are unsigned and signing them with the current project build signing identity value.
