### PR TITLE
Fixes unused function warning by aligning #if condition with header

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -492,7 +492,7 @@ void LoggerFlush(Logger *logger, BOOL waitForConnection)
 	}
 }
 
-#if LOGGER_DEBUG||1
+#if LOGGER_DEBUG
 static void LoggerDbg(CFStringRef format, ...)
 {
 	// Internal debugging function


### PR DESCRIPTION
Xcode displays a warning that the function is not used if LOGGER_DEBUG is false.
