### PR TITLE
Restore conditional compilation to fix unused function warning

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -492,7 +492,7 @@ void LoggerFlush(Logger *logger, BOOL waitForConnection)
 	}
 }
 
-#if LOGGER_DEBUG||1
+#if LOGGER_DEBUG
 static void LoggerDbg(CFStringRef format, ...)
 {
 	// Internal debugging function


### PR DESCRIPTION
Xcode is emitting an used function warning because this conditional compilation was re-enabled. This patch just flips it back to being compiled out.
