### PR TITLE
Error hit saying not to import once.h directly 

### DIFF
--- a/Client Logger/iOS/LoggerClient.h
+++ b/Client Logger/iOS/LoggerClient.h
@@ -35,7 +35,7 @@
  */
 #import <unistd.h>
 #import <pthread.h>
-#import <dispatch/once.h>
+#import <dispatch/dispatch.h>
 #import <libkern/OSAtomic.h>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
Using iOS 7.1. When you import once.h this is hit -- 
# ifndef **DISPATCH_INDIRECT**
# error "Please #include <dispatch/dispatch.h> instead of this file directly."
# include <dispatch/base.h> // for HeaderDoc
# endif

dispatch.h defines **DISPATCH_INDIRECT**
