### PR TITLE
Fix invalid access crash in iOS 8

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -2087,7 +2087,17 @@ static void LoggerMessageAddTimestampAndThreadID(CFMutableDataRef encoder)
 					// optimize CPU use by computing the thread name once and storing it back
 					// in the thread dictionary
 					name = [thread description];
-					NSRange range = [name rangeOfString:@"num = "];
+                    NSArray *threadNumberPrefixes = @[ @"num = ", @"number = " ];
+                    NSRange range = NSMakeRange(NSNotFound, 0);
+                    
+                    for (NSString *threadNumberPrefix in threadNumberPrefixes)
+                    {
+                        range = [name rangeOfString:threadNumberPrefix];
+                        
+                        if (range.location != NSNotFound)
+                            break;
+                    }
+					
 					if (range.location != NSNotFound)
 					{
 						name = [NSString stringWithFormat:@"Thread %@",


### PR DESCRIPTION
It seems that the format of -[NSThread description] has changed in iOS 8, which was causing NSLogger to crash for me.  This pull request fixes an invalid access crash that might occur if the thread name can't be determined, and adds support for the new description format.
