### PR TITLE
Fix warning

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -2018,7 +2018,7 @@ static uint8_t *LoggerMessagePrepareForPart(CFMutableDataRef encoder, uint32_t r
 	CFIndex size = CFDataGetLength(encoder);
 	uint32_t oldSize = ntohl(*(uint32_t *)p);
 	uint32_t newSize = oldSize + requiredExtraBytes;
-	if ((newSize + 4) > size)
+	if ((newSize + 4) > (uint32_t)size)
 	{
 		// grow by 64 bytes chunks
 		CFDataSetLength(encoder, (newSize + 4 + 64) & ~63);


### PR DESCRIPTION
Integers of different signs are being compared here. It is safe to assume that CFDataGetLength(encoder) will return 0 or a positive int, so an explicit cast is used to silence the warning.
