### PR TITLE
Fix crash on empty marker

### DIFF
--- a/Desktop Viewer/Classes/LoggerWindowController.m
+++ b/Desktop Viewer/Classes/LoggerWindowController.m
@@ -1692,7 +1692,7 @@ didReceiveMessages:(NSArray *)theMessages
 	}
 	else for (LoggerMessage *mark in marks)
 	{
-		NSMenuItem *markItem = [[NSMenuItem alloc] initWithTitle:mark.message
+		NSMenuItem *markItem = [[NSMenuItem alloc] initWithTitle:mark.message ?: @""
 														  action:@selector(jumpToMark:)
 												   keyEquivalent:@""];
 		[markItem setRepresentedObject:mark];


### PR DESCRIPTION
When a marker is added via `LogMarkerTo` and the text is an empty string, mark.message is nil and makes NSMenuItem initialization crash.