### PR TITLE
Guard

### DIFF
--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -1160,8 +1160,8 @@ static void LoggerStopConsoleRedirection()
 	close(sSTDOUT);
 	close(sSTDERR);
 
-    sSTDOUT = -1;
-    sSTDERR = -1;
+	sSTDOUT = -1;
+	sSTDERR = -1;
     
 	// restore sigpipe flag on standard streams
 	fcntl(STDOUT_FILENO, F_SETNOSIGPIPE, &sSTDOUThadSIGPIPE);

--- a/Client Logger/iOS/LoggerClient.m
+++ b/Client Logger/iOS/LoggerClient.m
@@ -1160,6 +1160,9 @@ static void LoggerStopConsoleRedirection()
 	close(sSTDOUT);
 	close(sSTDERR);
 
+    sSTDOUT = -1;
+    sSTDERR = -1;
+    
 	// restore sigpipe flag on standard streams
 	fcntl(STDOUT_FILENO, F_SETNOSIGPIPE, &sSTDOUThadSIGPIPE);
 	fcntl(STDERR_FILENO, F_SETNOSIGPIPE, &sSTDERRhadSIGPIPE);


### PR DESCRIPTION
Reset sSTDOUT & sSTDERR back to initial value in LoggerStopConsoleRedirection() so that LoggerStartConsoleRedirection() does the right thing.