### PR TITLE
Bugfix for change Xcode buildingsetting

### DIFF
--- a/Client Logger/iOS/LoggerClient.h
+++ b/Client Logger/iOS/LoggerClient.h
@@ -35,7 +35,7 @@
  */
 #import <unistd.h>
 #import <pthread.h>
-#import <dispatch/once.h>
+#import <dispatch/dispatch.h>
 #import <libkern/OSAtomic.h>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
When change Xcode buildingsetting `C++ Language Dialect` and `C++ Standard Library` when integrate with VLC.