### PR TITLE
Added autolayout to logger window

### DIFF
--- a/Desktop Viewer/Resources/LoggerWindow.xib
+++ b/Desktop Viewer/Resources/LoggerWindow.xib
@@ -1,5673 +1,1043 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1060</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSArrayController</string>
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSPopUpButton</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSPredicateEditor</string>
-			<string>NSPredicateEditorRowTemplate</string>
-			<string>NSScrollView</string>
-			<string>NSScroller</string>
-			<string>NSSearchField</string>
-			<string>NSSearchFieldCell</string>
-			<string>NSSplitView</string>
-			<string>NSTableColumn</string>
-			<string>NSTableHeaderView</string>
-			<string>NSTableView</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSToolbar</string>
-			<string>NSToolbarFlexibleSpaceItem</string>
-			<string>NSToolbarItem</string>
-			<string>NSToolbarSeparatorItem</string>
-			<string>NSToolbarSpaceItem</string>
-			<string>NSUserDefaultsController</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1048">
-			<object class="NSCustomObject" id="1021">
-				<string key="NSClassName">LoggerWindowController</string>
-			</object>
-			<object class="NSCustomObject" id="1014">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1050">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="972006081">
-				<int key="NSWindowStyleMask">15</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{154, 384}, {885, 666}}</string>
-				<int key="NSWTFlags">1946157056</int>
-				<string key="NSWindowTitle">NSLogger</string>
-				<string key="NSWindowClass">NSWindow</string>
-				<object class="NSToolbar" key="NSViewClass" id="857264127">
-					<object class="NSMutableString" key="NSToolbarIdentifier">
-						<characters key="NS.bytes">5DBD9D22-9164-4AF7-9E9B-5493625C1150</characters>
-					</object>
-					<nil key="NSToolbarDelegate"/>
-					<bool key="NSToolbarPrefersToBeShown">YES</bool>
-					<bool key="NSToolbarShowsBaselineSeparator">YES</bool>
-					<bool key="NSToolbarAllowsUserCustomization">YES</bool>
-					<bool key="NSToolbarAutosavesConfiguration">YES</bool>
-					<int key="NSToolbarDisplayMode">1</int>
-					<int key="NSToolbarSizeMode">2</int>
-					<dictionary class="NSMutableDictionary" key="NSToolbarIBIdentifiedItems">
-						<object class="NSToolbarItem" key="1982BF4A-3218-428E-B152-FE3A19027668" id="608132524">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">1982BF4A-3218-428E-B152-FE3A19027668</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Quick Search</string>
-							<string key="NSToolbarItemPaletteLabel">Quick Search</string>
-							<string key="NSToolbarItemToolTip">Refine by filtering the current filter/tag/level settings on a search term</string>
-							<object class="NSSearchField" key="NSToolbarItemView" id="26638440">
-								<nil key="NSNextResponder"/>
-								<int key="NSvFlags">268</int>
-								<string key="NSFrame">{{0, 14}, {117, 22}}</string>
-								<bool key="NSEnabled">YES</bool>
-								<object class="NSSearchFieldCell" key="NSCell" id="490457310">
-									<int key="NSCellFlags">342884416</int>
-									<int key="NSCellFlags2">268436544</int>
-									<string key="NSContents"/>
-									<object class="NSFont" key="NSSupport" id="4432246">
-										<string key="NSName">LucidaGrande</string>
-										<double key="NSSize">13</double>
-										<int key="NSfFlags">1044</int>
-									</object>
-									<reference key="NSControlView" ref="26638440"/>
-									<bool key="NSDrawsBackground">YES</bool>
-									<int key="NSTextBezelStyle">1</int>
-									<object class="NSColor" key="NSBackgroundColor" id="186242573">
-										<int key="NSColorSpace">6</int>
-										<string key="NSCatalogName">System</string>
-										<string key="NSColorName">textBackgroundColor</string>
-										<object class="NSColor" key="NSColor">
-											<int key="NSColorSpace">3</int>
-											<bytes key="NSWhite">MQA</bytes>
-										</object>
-									</object>
-									<object class="NSColor" key="NSTextColor" id="474791504">
-										<int key="NSColorSpace">6</int>
-										<string key="NSCatalogName">System</string>
-										<string key="NSColorName">controlTextColor</string>
-										<object class="NSColor" key="NSColor" id="745683106">
-											<int key="NSColorSpace">3</int>
-											<bytes key="NSWhite">MAA</bytes>
-										</object>
-									</object>
-									<object class="NSButtonCell" key="NSSearchButtonCell">
-										<int key="NSCellFlags">0</int>
-										<int key="NSCellFlags2">0</int>
-										<string key="NSContents">search</string>
-										<reference key="NSControlView" ref="26638440"/>
-										<string key="NSAction">_searchFieldSearch:</string>
-										<reference key="NSTarget" ref="490457310"/>
-										<int key="NSButtonFlags">138690560</int>
-										<int key="NSButtonFlags2">0</int>
-										<string key="NSKeyEquivalent"/>
-										<int key="NSPeriodicDelay">400</int>
-										<int key="NSPeriodicInterval">75</int>
-									</object>
-									<object class="NSButtonCell" key="NSCancelButtonCell">
-										<int key="NSCellFlags">0</int>
-										<int key="NSCellFlags2">0</int>
-										<string key="NSContents">clear</string>
-										<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-											<dictionary class="NSMutableDictionary">
-												<string key="AXDescription">cancel</string>
-												<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-											</dictionary>
-										</array>
-										<reference key="NSControlView" ref="26638440"/>
-										<string key="NSAction">_searchFieldCancel:</string>
-										<reference key="NSTarget" ref="490457310"/>
-										<int key="NSButtonFlags">138690560</int>
-										<int key="NSButtonFlags2">0</int>
-										<string key="NSKeyEquivalent"/>
-										<int key="NSPeriodicDelay">400</int>
-										<int key="NSPeriodicInterval">75</int>
-									</object>
-									<int key="NSMaximumRecents">255</int>
-								</object>
-								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							</object>
-							<nil key="NSToolbarItemImage"/>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{96, 22}</string>
-							<string key="NSToolbarItemMaxSize">{162, 22}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">0</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarItem" key="6294782E-4A83-4551-9D6A-CC59FA9ABC83" id="958014623">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">6294782E-4A83-4551-9D6A-CC59FA9ABC83</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Save</string>
-							<string key="NSToolbarItemPaletteLabel">Save</string>
-							<string key="NSToolbarItemToolTip">Save this log file</string>
-							<nil key="NSToolbarItemView"/>
-							<object class="NSCustomResource" key="NSToolbarItemImage">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">Save</string>
-							</object>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{0, 0}</string>
-							<string key="NSToolbarItemMaxSize">{0, 0}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarItem" key="7DE133D5-E674-4629-B2D2-B312C9263D42" id="1009168716">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">7DE133D5-E674-4629-B2D2-B312C9263D42</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Preferences</string>
-							<string key="NSToolbarItemPaletteLabel">Preferences</string>
-							<string key="NSToolbarItemToolTip">Open the Preferences window</string>
-							<nil key="NSToolbarItemView"/>
-							<object class="NSCustomResource" key="NSToolbarItemImage">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">NSAdvanced</string>
-							</object>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{0, 0}</string>
-							<string key="NSToolbarItemMaxSize">{0, 0}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarItem" key="9B2629AC-F52B-4881-AE8F-19A7A561CE6C" id="50987833">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">9B2629AC-F52B-4881-AE8F-19A7A561CE6C</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Application Runs</string>
-							<string key="NSToolbarItemPaletteLabel">Application Runs</string>
-							<nil key="NSToolbarItemToolTip"/>
-							<object class="NSPopUpButton" key="NSToolbarItemView" id="336153473">
-								<nil key="NSNextResponder"/>
-								<int key="NSvFlags">268</int>
-								<string key="NSFrame">{{0, 14}, {100, 25}}</string>
-								<bool key="NSEnabled">YES</bool>
-								<object class="NSPopUpButtonCell" key="NSCell" id="938642101">
-									<int key="NSCellFlags">-2080374720</int>
-									<int key="NSCellFlags2">2048</int>
-									<reference key="NSSupport" ref="4432246"/>
-									<reference key="NSControlView" ref="336153473"/>
-									<int key="NSButtonFlags">-2038284288</int>
-									<int key="NSButtonFlags2">163</int>
-									<string key="NSAlternateContents"/>
-									<string key="NSKeyEquivalent"/>
-									<int key="NSPeriodicDelay">400</int>
-									<int key="NSPeriodicInterval">75</int>
-									<object class="NSMenuItem" key="NSMenuItem" id="832166084">
-										<reference key="NSMenu" ref="714326863"/>
-										<string key="NSTitle">Item 1</string>
-										<string key="NSKeyEquiv"/>
-										<int key="NSKeyEquivModMask">1048576</int>
-										<int key="NSMnemonicLoc">2147483647</int>
-										<int key="NSState">1</int>
-										<object class="NSCustomResource" key="NSOnImage" id="13266356">
-											<string key="NSClassName">NSImage</string>
-											<string key="NSResourceName">NSMenuCheckmark</string>
-										</object>
-										<object class="NSCustomResource" key="NSMixedImage" id="1054000876">
-											<string key="NSClassName">NSImage</string>
-											<string key="NSResourceName">NSMenuMixedState</string>
-										</object>
-										<string key="NSAction">_popUpItemAction:</string>
-										<reference key="NSTarget" ref="938642101"/>
-									</object>
-									<bool key="NSMenuItemRespectAlignment">YES</bool>
-									<object class="NSMenu" key="NSMenu" id="714326863">
-										<string key="NSTitle">OtherViews</string>
-										<array class="NSMutableArray" key="NSMenuItems">
-											<reference ref="832166084"/>
-											<object class="NSMenuItem" id="741388438">
-												<reference key="NSMenu" ref="714326863"/>
-												<string key="NSTitle">Item 2</string>
-												<string key="NSKeyEquiv"/>
-												<int key="NSKeyEquivModMask">1048576</int>
-												<int key="NSMnemonicLoc">2147483647</int>
-												<reference key="NSOnImage" ref="13266356"/>
-												<reference key="NSMixedImage" ref="1054000876"/>
-												<string key="NSAction">_popUpItemAction:</string>
-												<reference key="NSTarget" ref="938642101"/>
-											</object>
-											<object class="NSMenuItem" id="349154456">
-												<reference key="NSMenu" ref="714326863"/>
-												<string key="NSTitle">Item 3</string>
-												<string key="NSKeyEquiv"/>
-												<int key="NSKeyEquivModMask">1048576</int>
-												<int key="NSMnemonicLoc">2147483647</int>
-												<reference key="NSOnImage" ref="13266356"/>
-												<reference key="NSMixedImage" ref="1054000876"/>
-												<string key="NSAction">_popUpItemAction:</string>
-												<reference key="NSTarget" ref="938642101"/>
-											</object>
-										</array>
-										<reference key="NSMenuFont" ref="4432246"/>
-									</object>
-									<int key="NSSelectedIndex">-1</int>
-									<int key="NSPreferredEdge">1</int>
-									<bool key="NSUsesItemFromMenu">YES</bool>
-									<bool key="NSAltersState">YES</bool>
-									<int key="NSArrowPosition">2</int>
-								</object>
-								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-							</object>
-							<nil key="NSToolbarItemImage"/>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{100, 25}</string>
-							<string key="NSToolbarItemMaxSize">{100, 25}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">0</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarItem" key="A2826872-EE4D-44ED-94BA-C345D69E3C78" id="1072918009">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">A2826872-EE4D-44ED-94BA-C345D69E3C78</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Export</string>
-							<string key="NSToolbarItemPaletteLabel">Export</string>
-							<string key="NSToolbarItemToolTip">Export this log file to text format</string>
-							<nil key="NSToolbarItemView"/>
-							<object class="NSCustomResource" key="NSToolbarItemImage">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">Export</string>
-							</object>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{0, 0}</string>
-							<string key="NSToolbarItemMaxSize">{0, 0}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarItem" key="C88273F1-A03E-4796-BE78-D3529CFE1C4C" id="999087205">
-							<object class="NSMutableString" key="NSToolbarItemIdentifier">
-								<characters key="NS.bytes">C88273F1-A03E-4796-BE78-D3529CFE1C4C</characters>
-							</object>
-							<string key="NSToolbarItemLabel">Open</string>
-							<string key="NSToolbarItemPaletteLabel">Open</string>
-							<string key="NSToolbarItemToolTip">Open a log file</string>
-							<nil key="NSToolbarItemView"/>
-							<object class="NSCustomResource" key="NSToolbarItemImage">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">Load</string>
-							</object>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{0, 0}</string>
-							<string key="NSToolbarItemMaxSize">{0, 0}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-						</object>
-						<object class="NSToolbarFlexibleSpaceItem" key="NSToolbarFlexibleSpaceItem" id="727069989">
-							<string key="NSToolbarItemIdentifier">NSToolbarFlexibleSpaceItem</string>
-							<string key="NSToolbarItemLabel"/>
-							<string key="NSToolbarItemPaletteLabel">Flexible Space</string>
-							<nil key="NSToolbarItemToolTip"/>
-							<nil key="NSToolbarItemView"/>
-							<nil key="NSToolbarItemImage"/>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{1, 5}</string>
-							<string key="NSToolbarItemMaxSize">{20000, 32}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-							<object class="NSMenuItem" key="NSToolbarItemMenuFormRepresentation">
-								<bool key="NSIsDisabled">YES</bool>
-								<bool key="NSIsSeparator">YES</bool>
-								<string key="NSTitle"/>
-								<string key="NSKeyEquiv"/>
-								<int key="NSKeyEquivModMask">1048576</int>
-								<int key="NSMnemonicLoc">2147483647</int>
-								<reference key="NSOnImage" ref="13266356"/>
-								<reference key="NSMixedImage" ref="1054000876"/>
-							</object>
-						</object>
-						<object class="NSToolbarSeparatorItem" key="NSToolbarSeparatorItem" id="855220083">
-							<string key="NSToolbarItemIdentifier">NSToolbarSeparatorItem</string>
-							<string key="NSToolbarItemLabel"/>
-							<string key="NSToolbarItemPaletteLabel">Separator</string>
-							<nil key="NSToolbarItemToolTip"/>
-							<nil key="NSToolbarItemView"/>
-							<nil key="NSToolbarItemImage"/>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{12, 5}</string>
-							<string key="NSToolbarItemMaxSize">{12, 1000}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-							<object class="NSMenuItem" key="NSToolbarItemMenuFormRepresentation">
-								<bool key="NSIsDisabled">YES</bool>
-								<bool key="NSIsSeparator">YES</bool>
-								<string key="NSTitle"/>
-								<string key="NSKeyEquiv"/>
-								<int key="NSKeyEquivModMask">1048576</int>
-								<int key="NSMnemonicLoc">2147483647</int>
-								<reference key="NSOnImage" ref="13266356"/>
-								<reference key="NSMixedImage" ref="1054000876"/>
-							</object>
-						</object>
-						<object class="NSToolbarSpaceItem" key="NSToolbarSpaceItem" id="654955765">
-							<string key="NSToolbarItemIdentifier">NSToolbarSpaceItem</string>
-							<string key="NSToolbarItemLabel"/>
-							<string key="NSToolbarItemPaletteLabel">Space</string>
-							<nil key="NSToolbarItemToolTip"/>
-							<nil key="NSToolbarItemView"/>
-							<nil key="NSToolbarItemImage"/>
-							<nil key="NSToolbarItemTarget"/>
-							<nil key="NSToolbarItemAction"/>
-							<string key="NSToolbarItemMinSize">{32, 5}</string>
-							<string key="NSToolbarItemMaxSize">{32, 32}</string>
-							<bool key="NSToolbarItemEnabled">YES</bool>
-							<bool key="NSToolbarItemAutovalidates">YES</bool>
-							<int key="NSToolbarItemTag">-1</int>
-							<bool key="NSToolbarIsUserRemovable">YES</bool>
-							<int key="NSToolbarItemVisibilityPriority">0</int>
-							<object class="NSMenuItem" key="NSToolbarItemMenuFormRepresentation">
-								<bool key="NSIsDisabled">YES</bool>
-								<bool key="NSIsSeparator">YES</bool>
-								<string key="NSTitle"/>
-								<string key="NSKeyEquiv"/>
-								<int key="NSKeyEquivModMask">1048576</int>
-								<int key="NSMnemonicLoc">2147483647</int>
-								<reference key="NSOnImage" ref="13266356"/>
-								<reference key="NSMixedImage" ref="1054000876"/>
-							</object>
-						</object>
-					</dictionary>
-					<array key="NSToolbarIBAllowedItems">
-						<reference ref="999087205"/>
-						<reference ref="958014623"/>
-						<reference ref="1072918009"/>
-						<reference ref="1009168716"/>
-						<reference ref="654955765"/>
-						<reference ref="727069989"/>
-						<reference ref="608132524"/>
-						<reference ref="50987833"/>
-						<reference ref="855220083"/>
-					</array>
-					<array key="NSToolbarIBDefaultItems">
-						<reference ref="999087205"/>
-						<reference ref="958014623"/>
-						<reference ref="1072918009"/>
-						<reference ref="727069989"/>
-						<reference ref="50987833"/>
-						<reference ref="727069989"/>
-						<reference ref="1009168716"/>
-						<reference ref="608132524"/>
-					</array>
-					<array key="NSToolbarIBSelectableItems" id="0"/>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{700, 500}</string>
-				<object class="NSView" key="NSWindowView" id="439893737">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSSplitView" id="252816051">
-							<reference key="NSNextResponder" ref="439893737"/>
-							<int key="NSvFlags">4370</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSCustomView" id="797179158">
-									<reference key="NSNextResponder" ref="252816051"/>
-									<int key="NSvFlags">274</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSSplitView" id="136015987">
-											<reference key="NSNextResponder" ref="797179158"/>
-											<int key="NSvFlags">274</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSCustomView" id="196019381">
-													<reference key="NSNextResponder" ref="136015987"/>
-													<int key="NSvFlags">272</int>
-													<array class="NSMutableArray" key="NSSubviews">
-														<object class="NSScrollView" id="150030323">
-															<reference key="NSNextResponder" ref="196019381"/>
-															<int key="NSvFlags">274</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSClipView" id="840061019">
-																	<reference key="NSNextResponder" ref="150030323"/>
-																	<int key="NSvFlags">2304</int>
-																	<array class="NSMutableArray" key="NSSubviews">
-																		<object class="NSTableView" id="441275434">
-																			<reference key="NSNextResponder" ref="840061019"/>
-																			<int key="NSvFlags">4352</int>
-																			<array class="NSMutableArray" key="NSSubviews"/>
-																			<string key="NSFrameSize">{101, 239}</string>
-																			<reference key="NSSuperview" ref="840061019"/>
-																			<reference key="NSWindow"/>
-																			<reference key="NSNextKeyView" ref="802786105"/>
-																			<bool key="NSEnabled">YES</bool>
-																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																			<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-																			<object class="NSTableHeaderView" key="NSHeaderView" id="152728781">
-																				<reference key="NSNextResponder" ref="553456289"/>
-																				<int key="NSvFlags">8448</int>
-																				<string key="NSFrameSize">{101, 17}</string>
-																				<reference key="NSSuperview" ref="553456289"/>
-																				<reference key="NSWindow"/>
-																				<reference key="NSNextKeyView" ref="840061019"/>
-																				<reference key="NSTableView" ref="441275434"/>
-																			</object>
-																			<object class="_NSCornerView" key="NSCornerView">
-																				<nil key="NSNextResponder"/>
-																				<int key="NSvFlags">-2147483392</int>
-																				<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
-																			</object>
-																			<array class="NSMutableArray" key="NSTableColumns">
-																				<object class="NSTableColumn" id="612119745">
-																					<string key="NSIdentifier">filtersets</string>
-																					<double key="NSWidth">98</double>
-																					<double key="NSMinWidth">40</double>
-																					<double key="NSMaxWidth">1000</double>
-																					<object class="NSTableHeaderCell" key="NSHeaderCell">
-																						<int key="NSCellFlags">75497536</int>
-																						<int key="NSCellFlags2">2048</int>
-																						<string key="NSContents">Application Sets</string>
-																						<object class="NSFont" key="NSSupport" id="26">
-																							<string key="NSName">LucidaGrande</string>
-																							<double key="NSSize">11</double>
-																							<int key="NSfFlags">3100</int>
-																						</object>
-																						<object class="NSColor" key="NSBackgroundColor">
-																							<int key="NSColorSpace">3</int>
-																							<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																						</object>
-																						<object class="NSColor" key="NSTextColor" id="1014530632">
-																							<int key="NSColorSpace">6</int>
-																							<string key="NSCatalogName">System</string>
-																							<string key="NSColorName">headerTextColor</string>
-																							<reference key="NSColor" ref="745683106"/>
-																						</object>
-																					</object>
-																					<object class="NSTextFieldCell" key="NSDataCell" id="628322093">
-																						<int key="NSCellFlags">67108928</int>
-																						<int key="NSCellFlags2">4200448</int>
-																						<string key="NSContents">Text Cell</string>
-																						<reference key="NSSupport" ref="4432246"/>
-																						<reference key="NSControlView" ref="441275434"/>
-																						<object class="NSColor" key="NSBackgroundColor" id="95618980">
-																							<int key="NSColorSpace">6</int>
-																							<string key="NSCatalogName">System</string>
-																							<string key="NSColorName">controlBackgroundColor</string>
-																							<object class="NSColor" key="NSColor" id="362555436">
-																								<int key="NSColorSpace">3</int>
-																								<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-																							</object>
-																						</object>
-																						<reference key="NSTextColor" ref="474791504"/>
-																					</object>
-																					<int key="NSResizingMask">3</int>
-																					<bool key="NSIsResizeable">YES</bool>
-																					<bool key="NSIsEditable">YES</bool>
-																					<reference key="NSTableView" ref="441275434"/>
-																				</object>
-																			</array>
-																			<double key="NSIntercellSpacingWidth">3</double>
-																			<double key="NSIntercellSpacingHeight">2</double>
-																			<object class="NSColor" key="NSBackgroundColor">
-																				<int key="NSColorSpace">6</int>
-																				<string key="NSCatalogName">System</string>
-																				<string key="NSColorName">_sourceListBackgroundColor</string>
-																				<object class="NSColor" key="NSColor" id="193023728">
-																					<int key="NSColorSpace">6</int>
-																					<string key="NSCatalogName">System</string>
-																					<string key="NSColorName">alternateSelectedControlColor</string>
-																					<object class="NSColor" key="NSColor">
-																						<int key="NSColorSpace">1</int>
-																						<bytes key="NSRGB">MCAwIDEAA</bytes>
-																					</object>
-																				</object>
-																			</object>
-																			<object class="NSColor" key="NSGridColor" id="844425564">
-																				<int key="NSColorSpace">6</int>
-																				<string key="NSCatalogName">System</string>
-																				<string key="NSColorName">gridColor</string>
-																				<object class="NSColor" key="NSColor">
-																					<int key="NSColorSpace">3</int>
-																					<bytes key="NSWhite">MC41AA</bytes>
-																				</object>
-																			</object>
-																			<double key="NSRowHeight">20</double>
-																			<int key="NSTvFlags">37748736</int>
-																			<reference key="NSDelegate"/>
-																			<reference key="NSDataSource"/>
-																			<int key="NSColumnAutoresizingStyle">5</int>
-																			<int key="NSDraggingSourceMaskForLocal">15</int>
-																			<int key="NSDraggingSourceMaskForNonLocal">0</int>
-																			<bool key="NSAllowsTypeSelect">NO</bool>
-																			<int key="NSTableViewSelectionHighlightStyle">1</int>
-																			<int key="NSTableViewDraggingDestinationStyle">1</int>
-																			<int key="NSTableViewGroupRowStyle">1</int>
-																		</object>
-																	</array>
-																	<string key="NSFrame">{{0, 17}, {101, 239}}</string>
-																	<reference key="NSSuperview" ref="150030323"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="441275434"/>
-																	<reference key="NSDocView" ref="441275434"/>
-																	<reference key="NSBGColor" ref="95618980"/>
-																	<int key="NScvFlags">4</int>
-																</object>
-																<object class="NSScroller" id="563313961">
-																	<reference key="NSNextResponder" ref="150030323"/>
-																	<int key="NSvFlags">-2147483392</int>
-																	<string key="NSFrame">{{201, 17}, {15, 614}}</string>
-																	<reference key="NSSuperview" ref="150030323"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="150906237"/>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	<reference key="NSTarget" ref="150030323"/>
-																	<string key="NSAction">_doScroller:</string>
-																	<double key="NSCurValue">0.46957153231663029</double>
-																	<double key="NSPercent">0.99642854928970337</double>
-																</object>
-																<object class="NSScroller" id="802786105">
-																	<reference key="NSNextResponder" ref="150030323"/>
-																	<int key="NSvFlags">-2147483392</int>
-																	<string key="NSFrame">{{-100, -100}, {200, 15}}</string>
-																	<reference key="NSSuperview" ref="150030323"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="553456289"/>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	<int key="NSsFlags">1</int>
-																	<reference key="NSTarget" ref="150030323"/>
-																	<string key="NSAction">_doScroller:</string>
-																	<double key="NSPercent">0.96598637104034424</double>
-																</object>
-																<object class="NSClipView" id="553456289">
-																	<reference key="NSNextResponder" ref="150030323"/>
-																	<int key="NSvFlags">2304</int>
-																	<array class="NSMutableArray" key="NSSubviews">
-																		<reference ref="152728781"/>
-																	</array>
-																	<string key="NSFrameSize">{101, 17}</string>
-																	<reference key="NSSuperview" ref="150030323"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="152728781"/>
-																	<reference key="NSDocView" ref="152728781"/>
-																	<reference key="NSBGColor" ref="95618980"/>
-																	<int key="NScvFlags">4</int>
-																</object>
-															</array>
-															<string key="NSFrame">{{0, 24}, {101, 256}}</string>
-															<reference key="NSSuperview" ref="196019381"/>
-															<reference key="NSWindow"/>
-															<reference key="NSNextKeyView" ref="840061019"/>
-															<int key="NSsFlags">133648</int>
-															<reference key="NSVScroller" ref="563313961"/>
-															<reference key="NSHScroller" ref="802786105"/>
-															<reference key="NSContentView" ref="840061019"/>
-															<reference key="NSHeaderClipView" ref="553456289"/>
-															<bytes key="NSScrollAmts">QSAAAEEgAABBsAAAQbAAAA</bytes>
-															<double key="NSMinMagnification">0.25</double>
-															<double key="NSMaxMagnification">4</double>
-															<double key="NSMagnification">1</double>
-														</object>
-														<object class="NSCustomView" id="150906237">
-															<reference key="NSNextResponder" ref="196019381"/>
-															<int key="NSvFlags">290</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSButton" id="179564853">
-																	<reference key="NSNextResponder" ref="150906237"/>
-																	<int key="NSvFlags">268</int>
-																	<string key="NSFrame">{{-1, -1}, {32, 24}}</string>
-																	<reference key="NSSuperview" ref="150906237"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="206027241"/>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSButtonCell" key="NSCell" id="332977932">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents"/>
-																		<reference key="NSSupport" ref="26"/>
-																		<reference key="NSControlView" ref="179564853"/>
-																		<int key="NSButtonFlags">-2033958912</int>
-																		<int key="NSButtonFlags2">163</int>
-																		<object class="NSCustomResource" key="NSNormalImage" id="48950744">
-																			<string key="NSClassName">NSImage</string>
-																			<string key="NSResourceName">NSAddTemplate</string>
-																		</object>
-																		<string key="NSAlternateContents"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">200</int>
-																		<int key="NSPeriodicInterval">25</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSButton" id="206027241">
-																	<reference key="NSNextResponder" ref="150906237"/>
-																	<int key="NSvFlags">268</int>
-																	<string key="NSFrame">{{30, -1}, {32, 24}}</string>
-																	<reference key="NSSuperview" ref="150906237"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="624715448"/>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSButtonCell" key="NSCell" id="253161491">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents"/>
-																		<reference key="NSSupport" ref="26"/>
-																		<reference key="NSControlView" ref="206027241"/>
-																		<int key="NSButtonFlags">-2033434624</int>
-																		<int key="NSButtonFlags2">163</int>
-																		<object class="NSCustomResource" key="NSNormalImage" id="714783570">
-																			<string key="NSClassName">NSImage</string>
-																			<string key="NSResourceName">NSRemoveTemplate</string>
-																		</object>
-																		<string key="NSAlternateContents"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">200</int>
-																		<int key="NSPeriodicInterval">25</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-															</array>
-															<string key="NSFrameSize">{101, 24}</string>
-															<reference key="NSSuperview" ref="196019381"/>
-															<reference key="NSWindow"/>
-															<reference key="NSNextKeyView" ref="179564853"/>
-															<string key="NSClassName">BWAnchoredButtonBar</string>
-														</object>
-													</array>
-													<string key="NSFrameSize">{100, 280}</string>
-													<reference key="NSSuperview" ref="136015987"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="150030323"/>
-													<string key="NSClassName">NSView</string>
-												</object>
-												<object class="NSCustomView" id="624715448">
-													<reference key="NSNextResponder" ref="136015987"/>
-													<int key="NSvFlags">272</int>
-													<array class="NSMutableArray" key="NSSubviews">
-														<object class="NSScrollView" id="624289750">
-															<reference key="NSNextResponder" ref="624715448"/>
-															<int key="NSvFlags">274</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSClipView" id="70922810">
-																	<reference key="NSNextResponder" ref="624289750"/>
-																	<int key="NSvFlags">2304</int>
-																	<array class="NSMutableArray" key="NSSubviews">
-																		<object class="NSTableView" id="150938961">
-																			<reference key="NSNextResponder" ref="70922810"/>
-																			<int key="NSvFlags">4352</int>
-																			<string key="NSFrameSize">{101, 339}</string>
-																			<reference key="NSSuperview" ref="70922810"/>
-																			<reference key="NSWindow"/>
-																			<reference key="NSNextKeyView" ref="682997029"/>
-																			<bool key="NSEnabled">YES</bool>
-																			<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																			<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-																			<object class="NSTableHeaderView" key="NSHeaderView" id="697792232">
-																				<reference key="NSNextResponder" ref="710855198"/>
-																				<int key="NSvFlags">8448</int>
-																				<string key="NSFrameSize">{101, 17}</string>
-																				<reference key="NSSuperview" ref="710855198"/>
-																				<reference key="NSWindow"/>
-																				<reference key="NSNextKeyView" ref="70922810"/>
-																				<reference key="NSTableView" ref="150938961"/>
-																			</object>
-																			<object class="_NSCornerView" key="NSCornerView">
-																				<nil key="NSNextResponder"/>
-																				<int key="NSvFlags">-2147483392</int>
-																				<string key="NSFrame">{{-26, 0}, {16, 17}}</string>
-																			</object>
-																			<array class="NSMutableArray" key="NSTableColumns">
-																				<object class="NSTableColumn" id="34494719">
-																					<string key="NSIdentifier">filters</string>
-																					<double key="NSWidth">98</double>
-																					<double key="NSMinWidth">40</double>
-																					<double key="NSMaxWidth">1000</double>
-																					<object class="NSTableHeaderCell" key="NSHeaderCell">
-																						<int key="NSCellFlags">75497536</int>
-																						<int key="NSCellFlags2">2048</int>
-																						<string key="NSContents">Filters</string>
-																						<reference key="NSSupport" ref="26"/>
-																						<object class="NSColor" key="NSBackgroundColor">
-																							<int key="NSColorSpace">3</int>
-																							<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																						</object>
-																						<reference key="NSTextColor" ref="1014530632"/>
-																					</object>
-																					<object class="NSTextFieldCell" key="NSDataCell" id="871845118">
-																						<int key="NSCellFlags">337641536</int>
-																						<int key="NSCellFlags2">2048</int>
-																						<string key="NSContents">Text Cell</string>
-																						<reference key="NSSupport" ref="4432246"/>
-																						<reference key="NSControlView" ref="150938961"/>
-																						<reference key="NSBackgroundColor" ref="95618980"/>
-																						<reference key="NSTextColor" ref="474791504"/>
-																					</object>
-																					<int key="NSResizingMask">3</int>
-																					<bool key="NSIsResizeable">YES</bool>
-																					<reference key="NSTableView" ref="150938961"/>
-																				</object>
-																			</array>
-																			<double key="NSIntercellSpacingWidth">3</double>
-																			<double key="NSIntercellSpacingHeight">2</double>
-																			<object class="NSColor" key="NSBackgroundColor">
-																				<int key="NSColorSpace">6</int>
-																				<string key="NSCatalogName">System</string>
-																				<string key="NSColorName">_sourceListBackgroundColor</string>
-																				<reference key="NSColor" ref="193023728"/>
-																			</object>
-																			<reference key="NSGridColor" ref="844425564"/>
-																			<double key="NSRowHeight">20</double>
-																			<int key="NSTvFlags">171966464</int>
-																			<reference key="NSDelegate"/>
-																			<reference key="NSDataSource"/>
-																			<int key="NSColumnAutoresizingStyle">5</int>
-																			<int key="NSDraggingSourceMaskForLocal">15</int>
-																			<int key="NSDraggingSourceMaskForNonLocal">0</int>
-																			<bool key="NSAllowsTypeSelect">YES</bool>
-																			<int key="NSTableViewSelectionHighlightStyle">1</int>
-																			<int key="NSTableViewDraggingDestinationStyle">1</int>
-																			<int key="NSTableViewGroupRowStyle">1</int>
-																		</object>
-																	</array>
-																	<string key="NSFrame">{{0, 17}, {101, 339}}</string>
-																	<reference key="NSSuperview" ref="624289750"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="150938961"/>
-																	<reference key="NSDocView" ref="150938961"/>
-																	<reference key="NSBGColor" ref="95618980"/>
-																	<int key="NScvFlags">4</int>
-																</object>
-																<object class="NSScroller" id="940204013">
-																	<reference key="NSNextResponder" ref="624289750"/>
-																	<int key="NSvFlags">-2147483392</int>
-																	<string key="NSFrame">{{201, 17}, {15, 614}}</string>
-																	<reference key="NSSuperview" ref="624289750"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="1007791563"/>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	<reference key="NSTarget" ref="624289750"/>
-																	<string key="NSAction">_doScroller:</string>
-																	<double key="NSPercent">0.98051947355270386</double>
-																</object>
-																<object class="NSScroller" id="682997029">
-																	<reference key="NSNextResponder" ref="624289750"/>
-																	<int key="NSvFlags">-2147483392</int>
-																	<string key="NSFrame">{{-100, -100}, {200, 15}}</string>
-																	<reference key="NSSuperview" ref="624289750"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="710855198"/>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																	<int key="NSsFlags">1</int>
-																	<reference key="NSTarget" ref="624289750"/>
-																	<string key="NSAction">_doScroller:</string>
-																	<double key="NSCurValue">0.38532110091743121</double>
-																	<double key="NSPercent">0.96598637104034424</double>
-																</object>
-																<object class="NSClipView" id="710855198">
-																	<reference key="NSNextResponder" ref="624289750"/>
-																	<int key="NSvFlags">2304</int>
-																	<array class="NSMutableArray" key="NSSubviews">
-																		<reference ref="697792232"/>
-																	</array>
-																	<string key="NSFrameSize">{101, 17}</string>
-																	<reference key="NSSuperview" ref="624289750"/>
-																	<reference key="NSWindow"/>
-																	<reference key="NSNextKeyView" ref="697792232"/>
-																	<reference key="NSDocView" ref="697792232"/>
-																	<reference key="NSBGColor" ref="95618980"/>
-																	<int key="NScvFlags">4</int>
-																</object>
-															</array>
-															<string key="NSFrame">{{0, 1}, {101, 356}}</string>
-															<reference key="NSSuperview" ref="624715448"/>
-															<reference key="NSWindow"/>
-															<reference key="NSNextKeyView" ref="70922810"/>
-															<int key="NSsFlags">133648</int>
-															<reference key="NSVScroller" ref="940204013"/>
-															<reference key="NSHScroller" ref="682997029"/>
-															<reference key="NSContentView" ref="70922810"/>
-															<reference key="NSHeaderClipView" ref="710855198"/>
-															<bytes key="NSScrollAmts">QSAAAEEgAABBsAAAQbAAAA</bytes>
-															<double key="NSMinMagnification">0.25</double>
-															<double key="NSMaxMagnification">4</double>
-															<double key="NSMagnification">1</double>
-														</object>
-													</array>
-													<string key="NSFrame">{{0, 289}, {100, 357}}</string>
-													<reference key="NSSuperview" ref="136015987"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="624289750"/>
-													<string key="NSClassName">NSView</string>
-												</object>
-											</array>
-											<string key="NSFrame">{{0, 20}, {100, 646}}</string>
-											<reference key="NSSuperview" ref="797179158"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="196019381"/>
-											<string key="NSAutosaveName">SidebarSplit</string>
-											<object class="NSMutableDictionary" key="NSHoldingPriorities">
-												<integer value="0" key="NS.key.0"/>
-												<real value="490" key="NS.object.0"/>
-											</object>
-										</object>
-										<object class="NSCustomView" id="1007791563">
-											<reference key="NSNextResponder" ref="797179158"/>
-											<int key="NSvFlags">290</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSButton" id="983099424">
-													<reference key="NSNextResponder" ref="1007791563"/>
-													<int key="NSvFlags">268</int>
-													<string key="NSFrame">{{-1, -1}, {32, 24}}</string>
-													<reference key="NSSuperview" ref="1007791563"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="219283996"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSButtonCell" key="NSCell" id="303751880">
-														<int key="NSCellFlags">67108864</int>
-														<int key="NSCellFlags2">134348800</int>
-														<string key="NSContents"/>
-														<reference key="NSSupport" ref="26"/>
-														<reference key="NSControlView" ref="983099424"/>
-														<int key="NSButtonFlags">147079168</int>
-														<int key="NSButtonFlags2">35</int>
-														<reference key="NSNormalImage" ref="48950744"/>
-														<string key="NSAlternateContents"/>
-														<string key="NSKeyEquivalent"/>
-														<int key="NSPeriodicDelay">200</int>
-														<int key="NSPeriodicInterval">25</int>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-												<object class="NSButton" id="219283996">
-													<reference key="NSNextResponder" ref="1007791563"/>
-													<int key="NSvFlags">268</int>
-													<string key="NSFrame">{{30, -1}, {32, 24}}</string>
-													<reference key="NSSuperview" ref="1007791563"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="161733749"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSButtonCell" key="NSCell" id="94898094">
-														<int key="NSCellFlags">67108864</int>
-														<int key="NSCellFlags2">134348800</int>
-														<string key="NSContents"/>
-														<reference key="NSSupport" ref="26"/>
-														<reference key="NSControlView" ref="219283996"/>
-														<int key="NSButtonFlags">147603456</int>
-														<int key="NSButtonFlags2">35</int>
-														<reference key="NSNormalImage" ref="714783570"/>
-														<string key="NSAlternateContents"/>
-														<string key="NSKeyEquivalent"/>
-														<int key="NSPeriodicDelay">200</int>
-														<int key="NSPeriodicInterval">25</int>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-											</array>
-											<string key="NSFrameSize">{100, 23}</string>
-											<reference key="NSSuperview" ref="797179158"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="983099424"/>
-											<string key="NSClassName">BWAnchoredButtonBar</string>
-										</object>
-									</array>
-									<string key="NSFrameSize">{100, 673}</string>
-									<reference key="NSSuperview" ref="252816051"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="136015987"/>
-									<string key="NSClassName">NSView</string>
-								</object>
-								<object class="NSCustomView" id="161733749">
-									<reference key="NSNextResponder" ref="252816051"/>
-									<int key="NSvFlags">274</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSCustomView" id="919832767">
-											<reference key="NSNextResponder" ref="161733749"/>
-											<int key="NSvFlags">4386</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSPopUpButton" id="622971220">
-													<reference key="NSNextResponder" ref="919832767"/>
-													<int key="NSvFlags">289</int>
-													<string key="NSFrame">{{603, -1}, {165, 23}}</string>
-													<reference key="NSSuperview" ref="919832767"/>
-													<reference key="NSWindow"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSPopUpButtonCell" key="NSCell" id="319025651">
-														<int key="NSCellFlags">71303232</int>
-														<int key="NSCellFlags2">134220032</int>
-														<object class="NSFont" key="NSSupport" id="781454291">
-															<string key="NSName">LucidaGrande</string>
-															<double key="NSSize">11</double>
-															<int key="NSfFlags">16</int>
-														</object>
-														<reference key="NSControlView" ref="622971220"/>
-														<int key="NSButtonFlags">-2036842496</int>
-														<int key="NSButtonFlags2">164</int>
-														<string key="NSAlternateContents"/>
-														<string key="NSKeyEquivalent"/>
-														<int key="NSPeriodicDelay">400</int>
-														<int key="NSPeriodicInterval">75</int>
-														<object class="NSMenuItem" key="NSMenuItem" id="267491286">
-															<reference key="NSMenu" ref="404327897"/>
-															<bool key="NSIsHidden">YES</bool>
-															<string key="NSTitle"/>
-															<string key="NSKeyEquiv"/>
-															<int key="NSMnemonicLoc">2147483647</int>
-															<reference key="NSOnImage" ref="13266356"/>
-															<reference key="NSMixedImage" ref="1054000876"/>
-															<string key="NSAction">_popUpItemAction:</string>
-															<reference key="NSTarget" ref="319025651"/>
-														</object>
-														<bool key="NSMenuItemRespectAlignment">YES</bool>
-														<object class="NSMenu" key="NSMenu" id="404327897">
-															<string key="NSTitle">OtherViews</string>
-															<array class="NSMutableArray" key="NSMenuItems">
-																<reference ref="267491286"/>
-																<object class="NSMenuItem" id="779670545">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<string key="NSTitle">All Levels</string>
-																	<string key="NSKeyEquiv">=</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="443333885">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<int key="NSIndent">1</int>
-																	<string key="NSTitle">Level 0</string>
-																	<string key="NSKeyEquiv">0</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">1</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="1063259389">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<int key="NSIndent">1</int>
-																	<string key="NSTitle">Level ≤ 1</string>
-																	<string key="NSKeyEquiv">1</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">2</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="941498601">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<int key="NSIndent">1</int>
-																	<string key="NSTitle">Level ≤ 2</string>
-																	<string key="NSKeyEquiv">2</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">3</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="599580337">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<int key="NSIndent">1</int>
-																	<string key="NSTitle">Level ≤ 3</string>
-																	<string key="NSKeyEquiv">3</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">4</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="318690278">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<int key="NSIndent">1</int>
-																	<string key="NSTitle">Level ≤ 4</string>
-																	<string key="NSKeyEquiv">4</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">5</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="76018638">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<bool key="NSIsSeparator">YES</bool>
-																	<string key="NSTitle"/>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">-1</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-																<object class="NSMenuItem" id="751047399">
-																	<reference key="NSMenu" ref="404327897"/>
-																	<string key="NSTitle">All Tags</string>
-																	<string key="NSKeyEquiv">*</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<int key="NSTag">-1</int>
-																	<reference key="NSTarget" ref="319025651"/>
-																</object>
-															</array>
-															<reference key="NSMenuFont" ref="4432246"/>
-														</object>
-														<int key="NSSelectedIndex">-1</int>
-														<bool key="NSPullDown">YES</bool>
-														<int key="NSPreferredEdge">2</int>
-														<bool key="NSUsesItemFromMenu">YES</bool>
-														<bool key="NSAltersState">YES</bool>
-														<int key="NSArrowPosition">2</int>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-												<object class="NSTextField" id="984409547">
-													<reference key="NSNextResponder" ref="919832767"/>
-													<int key="NSvFlags">266</int>
-													<string key="NSFrame">{{63, 3}, {535, 14}}</string>
-													<reference key="NSSuperview" ref="919832767"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="622971220"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSTextFieldCell" key="NSCell" id="166932449">
-														<int key="NSCellFlags">67108928</int>
-														<int key="NSCellFlags2">272763392</int>
-														<string key="NSContents"/>
-														<reference key="NSSupport" ref="781454291"/>
-														<reference key="NSControlView" ref="984409547"/>
-														<object class="NSColor" key="NSBackgroundColor">
-															<int key="NSColorSpace">1</int>
-															<bytes key="NSRGB">MSAxIDAuNDAwMDAwMDA2AA</bytes>
-														</object>
-														<reference key="NSTextColor" ref="474791504"/>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-												<object class="NSButton" id="692175765">
-													<reference key="NSNextResponder" ref="919832767"/>
-													<int key="NSvFlags">268</int>
-													<string key="NSFrame">{{30, -1}, {28, 24}}</string>
-													<reference key="NSSuperview" ref="919832767"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSButtonCell" key="NSCell" id="407396953">
-														<int key="NSCellFlags">68157504</int>
-														<int key="NSCellFlags2">134349824</int>
-														<string key="NSContents">ƒ</string>
-														<object class="NSFont" key="NSSupport">
-															<string key="NSName">LucidaGrande-Bold</string>
-															<double key="NSSize">11</double>
-															<int key="NSfFlags">16</int>
-														</object>
-														<reference key="NSControlView" ref="692175765"/>
-														<int key="NSButtonFlags">-927711232</int>
-														<int key="NSButtonFlags2">35</int>
-														<string key="NSAlternateContents"/>
-														<string key="NSKeyEquivalent"/>
-														<int key="NSPeriodicDelay">200</int>
-														<int key="NSPeriodicInterval">25</int>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-												<object class="NSPopUpButton" id="531691545">
-													<reference key="NSNextResponder" ref="919832767"/>
-													<int key="NSvFlags">268</int>
-													<string key="NSFrame">{{-1, -1}, {32, 24}}</string>
-													<reference key="NSSuperview" ref="919832767"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="692175765"/>
-													<bool key="NSEnabled">YES</bool>
-													<object class="NSPopUpButtonCell" key="NSCell" id="672475580">
-														<int key="NSCellFlags">-2076180416</int>
-														<int key="NSCellFlags2">134350848</int>
-														<object class="NSFont" key="NSSupport">
-															<string key="NSName">LucidaGrande</string>
-															<double key="NSSize">13</double>
-															<int key="NSfFlags">16</int>
-														</object>
-														<reference key="NSControlView" ref="531691545"/>
-														<int key="NSButtonFlags">-2038284288</int>
-														<int key="NSButtonFlags2">163</int>
-														<string key="NSAlternateContents"/>
-														<string key="NSKeyEquivalent"/>
-														<int key="NSPeriodicDelay">400</int>
-														<int key="NSPeriodicInterval">75</int>
-														<object class="NSMenuItem" key="NSMenuItem" id="634578148">
-															<reference key="NSMenu" ref="14458767"/>
-															<bool key="NSIsHidden">YES</bool>
-															<string key="NSTitle"/>
-															<string key="NSKeyEquiv"/>
-															<int key="NSKeyEquivModMask">1048576</int>
-															<int key="NSMnemonicLoc">2147483647</int>
-															<object class="NSCustomResource" key="NSImage">
-																<string key="NSClassName">NSImage</string>
-																<string key="NSResourceName">NSActionTemplate</string>
-															</object>
-															<reference key="NSOnImage" ref="13266356"/>
-															<reference key="NSMixedImage" ref="1054000876"/>
-															<string key="NSAction">_popUpItemAction:</string>
-															<reference key="NSTarget" ref="672475580"/>
-														</object>
-														<bool key="NSMenuItemRespectAlignment">YES</bool>
-														<object class="NSMenu" key="NSMenu" id="14458767">
-															<string key="NSTitle">OtherViews</string>
-															<array class="NSMutableArray" key="NSMenuItems">
-																<reference ref="634578148"/>
-																<object class="NSMenuItem" id="895409037">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<string key="NSTitle">Open Details Window</string>
-																	<string key="NSKeyEquiv">i</string>
-																	<int key="NSKeyEquivModMask">1048576</int>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="598597192">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<bool key="NSIsSeparator">YES</bool>
-																	<string key="NSTitle"/>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="1071402364">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<string key="NSTitle">Reset Quick Filter</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="796904695">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<string key="NSTitle">New Filter from Quick Filter</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="537658706">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<bool key="NSIsSeparator">YES</bool>
-																	<string key="NSTitle"/>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="241913815">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<string key="NSTitle">Clear Log</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-																<object class="NSMenuItem" id="859424117">
-																	<reference key="NSMenu" ref="14458767"/>
-																	<bool key="NSIsDisabled">YES</bool>
-																	<string key="NSTitle">Clear All Run Logs</string>
-																	<string key="NSKeyEquiv"/>
-																	<int key="NSMnemonicLoc">2147483647</int>
-																	<reference key="NSOnImage" ref="13266356"/>
-																	<reference key="NSMixedImage" ref="1054000876"/>
-																	<string key="NSAction">_popUpItemAction:</string>
-																	<reference key="NSTarget" ref="672475580"/>
-																</object>
-															</array>
-														</object>
-														<bool key="NSPullDown">YES</bool>
-														<int key="NSPreferredEdge">1</int>
-														<bool key="NSUsesItemFromMenu">YES</bool>
-														<bool key="NSAltersState">YES</bool>
-														<int key="NSArrowPosition">2</int>
-													</object>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-												</object>
-											</array>
-											<string key="NSFrameSize">{784, 23}</string>
-											<reference key="NSSuperview" ref="161733749"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="531691545"/>
-											<string key="NSClassName">BWAnchoredButtonBar</string>
-										</object>
-										<object class="NSScrollView" id="1043255743">
-											<reference key="NSNextResponder" ref="161733749"/>
-											<int key="NSvFlags">274</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSClipView" id="364781866">
-													<reference key="NSNextResponder" ref="1043255743"/>
-													<int key="NSvFlags">2304</int>
-													<array class="NSMutableArray" key="NSSubviews">
-														<object class="NSTableView" id="522308002">
-															<reference key="NSNextResponder" ref="364781866"/>
-															<int key="NSvFlags">4370</int>
-															<string key="NSFrameSize">{784, 644}</string>
-															<reference key="NSSuperview" ref="364781866"/>
-															<reference key="NSWindow"/>
-															<reference key="NSNextKeyView" ref="426073056"/>
-															<bool key="NSEnabled">YES</bool>
-															<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-															<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-															<object class="_NSCornerView" key="NSCornerView">
-																<nil key="NSNextResponder"/>
-																<int key="NSvFlags">-2147483392</int>
-																<string key="NSFrame">{{652, 0}, {16, 17}}</string>
-															</object>
-															<array class="NSMutableArray" key="NSTableColumns">
-																<object class="NSTableColumn" id="759397915">
-																	<string key="NSIdentifier">message</string>
-																	<double key="NSWidth">781</double>
-																	<double key="NSMinWidth">200</double>
-																	<double key="NSMaxWidth">10000</double>
-																	<object class="NSTableHeaderCell" key="NSHeaderCell">
-																		<int key="NSCellFlags">75497536</int>
-																		<int key="NSCellFlags2">2048</int>
-																		<string key="NSContents"/>
-																		<reference key="NSSupport" ref="26"/>
-																		<object class="NSColor" key="NSBackgroundColor">
-																			<int key="NSColorSpace">3</int>
-																			<bytes key="NSWhite">MC4zMzMzMzI5ODU2AA</bytes>
-																		</object>
-																		<reference key="NSTextColor" ref="1014530632"/>
-																	</object>
-																	<object class="NSTextFieldCell" key="NSDataCell" id="738305309">
-																		<int key="NSCellFlags">337641536</int>
-																		<int key="NSCellFlags2">2048</int>
-																		<string key="NSContents">Text Cell</string>
-																		<reference key="NSSupport" ref="4432246"/>
-																		<reference key="NSControlView" ref="522308002"/>
-																		<reference key="NSBackgroundColor" ref="95618980"/>
-																		<reference key="NSTextColor" ref="474791504"/>
-																	</object>
-																	<int key="NSResizingMask">1</int>
-																	<bool key="NSIsResizeable">YES</bool>
-																	<bool key="NSIsEditable">YES</bool>
-																	<reference key="NSTableView" ref="522308002"/>
-																</object>
-															</array>
-															<double key="NSIntercellSpacingWidth">3</double>
-															<double key="NSIntercellSpacingHeight">2</double>
-															<object class="NSColor" key="NSBackgroundColor" id="246830643">
-																<int key="NSColorSpace">3</int>
-																<bytes key="NSWhite">MC45NzAwMDAwMjg2AA</bytes>
-															</object>
-															<object class="NSColor" key="NSGridColor">
-																<int key="NSColorSpace">1</int>
-																<bytes key="NSRGB">MC45MzkyMzg1NDgzIDAuOTM5MjM4NTQ4MyAwLjkzOTIzODU0ODMAA</bytes>
-															</object>
-															<double key="NSRowHeight">44</double>
-															<int key="NSTvFlags">1514143744</int>
-															<reference key="NSDelegate"/>
-															<reference key="NSDataSource"/>
-															<int key="NSColumnAutoresizingStyle">5</int>
-															<int key="NSDraggingSourceMaskForLocal">15</int>
-															<int key="NSDraggingSourceMaskForNonLocal">0</int>
-															<bool key="NSAllowsTypeSelect">NO</bool>
-															<int key="NSTableViewDraggingDestinationStyle">0</int>
-															<int key="NSTableViewGroupRowStyle">1</int>
-														</object>
-													</array>
-													<string key="NSFrameSize">{784, 644}</string>
-													<reference key="NSSuperview" ref="1043255743"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="522308002"/>
-													<reference key="NSDocView" ref="522308002"/>
-													<reference key="NSBGColor" ref="246830643"/>
-													<int key="NScvFlags">6</int>
-												</object>
-												<object class="NSScroller" id="122654608">
-													<reference key="NSNextResponder" ref="1043255743"/>
-													<int key="NSvFlags">256</int>
-													<string key="NSFrame">{{768, 0}, {16, 644}}</string>
-													<reference key="NSSuperview" ref="1043255743"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="919832767"/>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													<reference key="NSTarget" ref="1043255743"/>
-													<string key="NSAction">_doScroller:</string>
-													<double key="NSCurValue">0.97981366459627328</double>
-													<double key="NSPercent">0.9972299337387085</double>
-												</object>
-												<object class="NSScroller" id="426073056">
-													<reference key="NSNextResponder" ref="1043255743"/>
-													<int key="NSvFlags">-2147483392</int>
-													<string key="NSFrame">{{-100, -100}, {650, 15}}</string>
-													<reference key="NSSuperview" ref="1043255743"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="364781866"/>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													<int key="NSsFlags">1</int>
-													<reference key="NSTarget" ref="1043255743"/>
-													<string key="NSAction">_doScroller:</string>
-													<double key="NSCurValue">0.59969325153374209</double>
-													<double key="NSPercent">0.95238101482391357</double>
-												</object>
-											</array>
-											<string key="NSFrame">{{0, 22}, {784, 644}}</string>
-											<reference key="NSSuperview" ref="161733749"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="364781866"/>
-											<int key="NSsFlags">133136</int>
-											<reference key="NSVScroller" ref="122654608"/>
-											<reference key="NSHScroller" ref="426073056"/>
-											<reference key="NSContentView" ref="364781866"/>
-											<bytes key="NSScrollAmts">QSAAAEEgAABCOAAAQjgAAA</bytes>
-											<double key="NSMinMagnification">0.25</double>
-											<double key="NSMaxMagnification">4</double>
-											<double key="NSMagnification">1</double>
-										</object>
-									</array>
-									<string key="NSFrame">{{101, 0}, {784, 673}}</string>
-									<reference key="NSSuperview" ref="252816051"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="1043255743"/>
-									<string key="NSClassName">NSView</string>
-								</object>
-							</array>
-							<string key="NSFrameSize">{885, 673}</string>
-							<reference key="NSSuperview" ref="439893737"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="797179158"/>
-							<bool key="NSIsVertical">YES</bool>
-							<int key="NSDividerStyle">2</int>
-							<string key="NSAutosaveName">MainSplit</string>
-						</object>
-					</array>
-					<string key="NSFrameSize">{885, 666}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="252816051"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
-				<string key="NSMinSize">{700, 569}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<string key="NSFrameAutosaveName">MainWindow</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSWindowTemplate" id="585219689">
-				<int key="NSWindowStyleMask">265</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{183, 289}, {480, 270}}</string>
-				<int key="NSWTFlags">1685586944</int>
-				<string key="NSWindowTitle">Filter Editor</string>
-				<string key="NSWindowClass">NSWindow</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{400, 200}</string>
-				<object class="NSView" key="NSWindowView" id="825133058">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSScrollView" id="45475269">
-							<reference key="NSNextResponder" ref="825133058"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSClipView" id="595262929">
-									<reference key="NSNextResponder" ref="45475269"/>
-									<int key="NSvFlags">2304</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSPredicateEditor" id="244222353">
-											<reference key="NSNextResponder" ref="595262929"/>
-											<int key="NSvFlags">290</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="_NSRuleEditorViewSliceHolder" id="436362337">
-													<reference key="NSNextResponder" ref="244222353"/>
-													<int key="NSvFlags">274</int>
-													<array class="NSMutableArray" key="NSSubviews">
-														<object class="NSRuleEditorViewSliceRow" id="654456339">
-															<reference key="NSNextResponder" ref="436362337"/>
-															<int key="NSvFlags">290</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSButton" id="622440011">
-																	<reference key="NSNextResponder" ref="654456339"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{450, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="654456339"/>
-																	<reference key="NSNextKeyView" ref="532891414"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">+</string>
-																		<object class="NSFont" key="NSSupport" id="29">
-																			<string key="NSName">LucidaGrande-Bold</string>
-																			<double key="NSSize">12</double>
-																			<int key="NSfFlags">16</int>
-																		</object>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">add</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="622440011"/>
-																		<string key="NSAction">_addOption:</string>
-																		<reference key="NSTarget" ref="654456339"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<object class="NSFont" key="NSAlternateImage" id="28">
-																			<string key="NSName">LucidaGrande</string>
-																			<double key="NSSize">12</double>
-																			<int key="NSfFlags">4883</int>
-																		</object>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSButton" id="971499438">
-																	<reference key="NSNextResponder" ref="654456339"/>
-																	<int key="NSvFlags">-2147483391</int>
-																	<string key="NSFrame">{{430, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="654456339"/>
-																	<reference key="NSNextKeyView" ref="622440011"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">-</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">remove</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="971499438"/>
-																		<string key="NSAction">_deleteOption:</string>
-																		<reference key="NSTarget" ref="654456339"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="407208618">
-																	<reference key="NSNextResponder" ref="654456339"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{7, 3}, {58, 19}}</string>
-																	<reference key="NSSuperview" ref="654456339"/>
-																	<reference key="NSNextKeyView" ref="873844501"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="589483202">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<integer value="2" key="NSRepresentedObject"/>
-																		<reference key="NSControlView" ref="407208618"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="183674531">
-																			<reference key="NSMenu" ref="13684657"/>
-																			<string key="NSTitle">Any</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<integer value="2" key="NSRepObject"/>
-																			<reference key="NSTarget" ref="589483202"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="13684657">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="183674531"/>
-																				<object class="NSMenuItem" id="20213531">
-																					<reference key="NSMenu" ref="13684657"/>
-																					<string key="NSTitle">All</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="1" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="589483202"/>
-																				</object>
-																				<object class="NSMenuItem" id="814094273">
-																					<reference key="NSMenu" ref="13684657"/>
-																					<string key="NSTitle">None</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="0" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="589483202"/>
-																				</object>
-																			</array>
-																			<reference key="NSMenuFont" ref="26"/>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="873844501">
-																	<reference key="NSNextResponder" ref="654456339"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{71, 3}, {167, 19}}</string>
-																	<reference key="NSSuperview" ref="654456339"/>
-																	<reference key="NSNextKeyView" ref="971499438"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="959241235">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<reference key="NSControlView" ref="873844501"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="931469284">
-																			<reference key="NSMenu" ref="762256663"/>
-																			<string key="NSTitle">of the following are true</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<reference key="NSTarget" ref="959241235"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="762256663">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="931469284"/>
-																			</array>
-																			<reference key="NSMenuFont" ref="26"/>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-															</array>
-															<string key="NSFrameSize">{478, 25}</string>
-															<reference key="NSSuperview" ref="436362337"/>
-															<reference key="NSNextKeyView" ref="407208618"/>
-															<int key="NSRuleRowIndex">0</int>
-															<int key="NSRuleIndentation">0</int>
-															<reference key="NSContainingRuleEditorView" ref="244222353"/>
-															<nil key="NSRuleBackgroundColor"/>
-															<array class="NSMutableArray" key="NSRuleOptionViews">
-																<reference ref="407208618"/>
-																<reference ref="873844501"/>
-															</array>
-															<int key="NSRuleOptionFrames.count">2</int>
-															<string key="NSRuleOptionFrames.0">{{7, 3}, {58, 19}}</string>
-															<string key="NSRuleOptionFrames.1">{{71, 3}, {167, 19}}</string>
-															<array class="NSMutableArray" key="NSRuleOptionItems">
-																<dictionary class="NSMutableDictionary" id="831541601">
-																	<integer value="1" key="depth"/>
-																	<object class="NSPredicateEditorRowTemplate" key="pattern" id="996633552">
-																		<int key="NSPredicateTemplateType">2</int>
-																		<int key="NSPredicateTemplateOptions">0</int>
-																		<int key="NSPredicateTemplateModifier">0</int>
-																		<int key="NSPredicateTemplateLeftAttributeType">0</int>
-																		<int key="NSPredicateTemplateRightAttributeType">0</int>
-																		<array key="NSPredicateTemplateViews">
-																			<reference ref="407208618"/>
-																			<reference ref="873844501"/>
-																		</array>
-																		<bool key="NSPredicateTemplateLeftIsWildcard">NO</bool>
-																		<bool key="NSPredicateTemplateRightIsWildcard">NO</bool>
-																	</object>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="871628778">
-																	<integer value="2" key="depth"/>
-																	<reference key="pattern" ref="996633552"/>
-																</dictionary>
-															</array>
-															<int key="NSRuleOptionInitialFrames.count">2</int>
-															<string key="NSRuleOptionInitialFrames.0">{{7, 3}, {58, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.1">{{71, 3}, {167, 19}}</string>
-															<reference key="NSRuleOptionAddButton" ref="622440011"/>
-															<reference key="NSRuleOptionSubtractButton" ref="971499438"/>
-															<int key="NSRuleOptionRowType">0</int>
-															<int key="NSRuleOptionPlusButtonRowType">0</int>
-															<bool key="NSRuleOptionEditable">YES</bool>
-														</object>
-														<object class="NSRuleEditorViewSliceRow" id="532891414">
-															<reference key="NSNextResponder" ref="436362337"/>
-															<int key="NSvFlags">290</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSButton" id="520647935">
-																	<reference key="NSNextResponder" ref="532891414"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{450, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="532891414"/>
-																	<reference key="NSNextKeyView" ref="569675527"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">+</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">add</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="520647935"/>
-																		<string key="NSAction">_addOption:</string>
-																		<reference key="NSTarget" ref="532891414"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSButton" id="455269866">
-																	<reference key="NSNextResponder" ref="532891414"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{430, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="532891414"/>
-																	<reference key="NSNextKeyView" ref="520647935"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">-</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">remove</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="455269866"/>
-																		<string key="NSAction">_deleteOption:</string>
-																		<reference key="NSTarget" ref="532891414"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="952908386">
-																	<reference key="NSNextResponder" ref="532891414"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{37, 3}, {113, 19}}</string>
-																	<reference key="NSSuperview" ref="532891414"/>
-																	<reference key="NSNextKeyView" ref="719560781"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="593985638">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<object class="NSKeyPathExpression" key="NSRepresentedObject" id="529180575">
-																			<int key="NSExpressionType">3</int>
-																			<string key="NSSelectorName">valueForKey:</string>
-																			<object class="NSSelfExpression" key="NSOperand" id="1030886767">
-																				<int key="NSExpressionType">1</int>
-																			</object>
-																			<array class="NSMutableArray" key="NSArguments">
-																				<object class="NSKeyPathSpecifierExpression">
-																					<int key="NSExpressionType">10</int>
-																					<string key="NSKeyPath">messageType</string>
-																				</object>
-																			</array>
-																		</object>
-																		<reference key="NSControlView" ref="952908386"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="950009332">
-																			<reference key="NSMenu" ref="729858560"/>
-																			<string key="NSTitle">Message Type</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<reference key="NSRepObject" ref="529180575"/>
-																			<reference key="NSTarget" ref="593985638"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="729858560">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="950009332"/>
-																			</array>
-																			<reference key="NSMenuFont" ref="26"/>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="719560781">
-																	<reference key="NSNextResponder" ref="532891414"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{156, 3}, {67, 19}}</string>
-																	<reference key="NSSuperview" ref="532891414"/>
-																	<reference key="NSNextKeyView" ref="606793315"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="876295576">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<integer value="4" key="NSRepresentedObject"/>
-																		<reference key="NSControlView" ref="719560781"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="451760126">
-																			<reference key="NSMenu" ref="881984314"/>
-																			<string key="NSTitle">is</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<integer value="4" key="NSRepObject"/>
-																			<reference key="NSTarget" ref="876295576"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="881984314">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="451760126"/>
-																				<object class="NSMenuItem" id="251771017">
-																					<reference key="NSMenu" ref="881984314"/>
-																					<string key="NSTitle">is not</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="5" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="876295576"/>
-																				</object>
-																			</array>
-																			<reference key="NSMenuFont" ref="26"/>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="606793315">
-																	<reference key="NSNextResponder" ref="532891414"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{229, 3}, {155, 19}}</string>
-																	<reference key="NSSuperview" ref="532891414"/>
-																	<reference key="NSNextKeyView" ref="455269866"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="846541809">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<object class="NSConstantValueExpression" key="NSRepresentedObject" id="729869164">
-																			<int key="NSExpressionType">0</int>
-																			<string key="NSConstantValue">text</string>
-																		</object>
-																		<reference key="NSControlView" ref="606793315"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="322944491">
-																			<reference key="NSMenu" ref="1012339262"/>
-																			<string key="NSTitle">Text</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<reference key="NSRepObject" ref="729869164"/>
-																			<reference key="NSTarget" ref="846541809"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="1012339262">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="322944491"/>
-																				<object class="NSMenuItem" id="668684702">
-																					<reference key="NSMenu" ref="1012339262"/>
-																					<string key="NSTitle">Binary Data</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSConstantValueExpression" key="NSRepObject">
-																						<int key="NSExpressionType">0</int>
-																						<string key="NSConstantValue">data</string>
-																					</object>
-																					<reference key="NSTarget" ref="846541809"/>
-																				</object>
-																				<object class="NSMenuItem" id="791387877">
-																					<reference key="NSMenu" ref="1012339262"/>
-																					<string key="NSTitle">Image</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSConstantValueExpression" key="NSRepObject">
-																						<int key="NSExpressionType">0</int>
-																						<string key="NSConstantValue">img</string>
-																					</object>
-																					<reference key="NSTarget" ref="846541809"/>
-																				</object>
-																			</array>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-															</array>
-															<string key="NSFrame">{{0, 25}, {478, 25}}</string>
-															<reference key="NSSuperview" ref="436362337"/>
-															<reference key="NSNextKeyView" ref="952908386"/>
-															<int key="NSRuleRowIndex">1</int>
-															<int key="NSRuleIndentation">1</int>
-															<reference key="NSContainingRuleEditorView" ref="244222353"/>
-															<nil key="NSRuleBackgroundColor"/>
-															<array class="NSMutableArray" key="NSRuleOptionViews">
-																<reference ref="952908386"/>
-																<reference ref="719560781"/>
-																<reference ref="606793315"/>
-															</array>
-															<int key="NSRuleOptionFrames.count">3</int>
-															<string key="NSRuleOptionFrames.0">{{37, 3}, {113, 19}}</string>
-															<string key="NSRuleOptionFrames.1">{{156, 3}, {67, 19}}</string>
-															<string key="NSRuleOptionFrames.2">{{229, 3}, {155, 19}}</string>
-															<array class="NSMutableArray" key="NSRuleOptionItems">
-																<dictionary class="NSMutableDictionary" id="458174286">
-																	<integer value="1" key="depth"/>
-																	<object class="NSPredicateEditorRowTemplate" key="pattern" id="216723110">
-																		<int key="NSPredicateTemplateType">1</int>
-																		<int key="NSPredicateTemplateOptions">0</int>
-																		<int key="NSPredicateTemplateModifier">0</int>
-																		<int key="NSPredicateTemplateLeftAttributeType">0</int>
-																		<int key="NSPredicateTemplateRightAttributeType">0</int>
-																		<array key="NSPredicateTemplateViews">
-																			<reference ref="952908386"/>
-																			<reference ref="719560781"/>
-																			<reference ref="606793315"/>
-																		</array>
-																		<bool key="NSPredicateTemplateLeftIsWildcard">NO</bool>
-																		<bool key="NSPredicateTemplateRightIsWildcard">NO</bool>
-																	</object>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="787394286">
-																	<integer value="2" key="depth"/>
-																	<reference key="pattern" ref="216723110"/>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="331677407">
-																	<integer value="3" key="depth"/>
-																	<reference key="pattern" ref="216723110"/>
-																</dictionary>
-															</array>
-															<int key="NSRuleOptionInitialFrames.count">3</int>
-															<string key="NSRuleOptionInitialFrames.0">{{37, 3}, {113, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.1">{{156, 3}, {67, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.2">{{229, 3}, {155, 19}}</string>
-															<reference key="NSRuleOptionAddButton" ref="520647935"/>
-															<reference key="NSRuleOptionSubtractButton" ref="455269866"/>
-															<int key="NSRuleOptionRowType">0</int>
-															<int key="NSRuleOptionPlusButtonRowType">0</int>
-															<bool key="NSRuleOptionEditable">YES</bool>
-														</object>
-														<object class="NSRuleEditorViewSliceRow" id="569675527">
-															<reference key="NSNextResponder" ref="436362337"/>
-															<int key="NSvFlags">290</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSButton" id="814685270">
-																	<reference key="NSNextResponder" ref="569675527"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{450, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="569675527"/>
-																	<reference key="NSNextKeyView" ref="647529487"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">+</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">add</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="814685270"/>
-																		<string key="NSAction">_addOption:</string>
-																		<reference key="NSTarget" ref="569675527"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSButton" id="1021510370">
-																	<reference key="NSNextResponder" ref="569675527"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{430, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="569675527"/>
-																	<reference key="NSNextKeyView" ref="814685270"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">-</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">remove</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="1021510370"/>
-																		<string key="NSAction">_deleteOption:</string>
-																		<reference key="NSTarget" ref="569675527"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="228875584">
-																	<reference key="NSNextResponder" ref="569675527"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{37, 3}, {79, 19}}</string>
-																	<reference key="NSSuperview" ref="569675527"/>
-																	<reference key="NSNextKeyView" ref="745391060"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="412547117">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<object class="NSKeyPathExpression" key="NSRepresentedObject" id="546626147">
-																			<int key="NSExpressionType">3</int>
-																			<string key="NSSelectorName">valueForKey:</string>
-																			<reference key="NSOperand" ref="1030886767"/>
-																			<array class="NSMutableArray" key="NSArguments">
-																				<object class="NSKeyPathSpecifierExpression">
-																					<int key="NSExpressionType">10</int>
-																					<string key="NSKeyPath">messageText</string>
-																				</object>
-																			</array>
-																		</object>
-																		<reference key="NSControlView" ref="228875584"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="466785185">
-																			<reference key="NSMenu" ref="759074717"/>
-																			<string key="NSTitle">Message</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<reference key="NSRepObject" ref="546626147"/>
-																			<reference key="NSTarget" ref="412547117"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="759074717">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="466785185"/>
-																				<object class="NSMenuItem" id="728395743">
-																					<reference key="NSMenu" ref="759074717"/>
-																					<string key="NSTitle">Tag</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSKeyPathExpression" key="NSRepObject">
-																						<int key="NSExpressionType">3</int>
-																						<string key="NSSelectorName">valueForKey:</string>
-																						<reference key="NSOperand" ref="1030886767"/>
-																						<array class="NSMutableArray" key="NSArguments">
-																							<object class="NSKeyPathSpecifierExpression">
-																								<int key="NSExpressionType">10</int>
-																								<string key="NSKeyPath">tag</string>
-																							</object>
-																						</array>
-																					</object>
-																					<reference key="NSTarget" ref="412547117"/>
-																				</object>
-																				<object class="NSMenuItem" id="960006381">
-																					<reference key="NSMenu" ref="759074717"/>
-																					<string key="NSTitle">Thread Name</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSKeyPathExpression" key="NSRepObject">
-																						<int key="NSExpressionType">3</int>
-																						<string key="NSSelectorName">valueForKey:</string>
-																						<reference key="NSOperand" ref="1030886767"/>
-																						<array class="NSMutableArray" key="NSArguments">
-																							<object class="NSKeyPathSpecifierExpression">
-																								<int key="NSExpressionType">10</int>
-																								<string key="NSKeyPath">threadID</string>
-																							</object>
-																						</array>
-																					</object>
-																					<reference key="NSTarget" ref="412547117"/>
-																				</object>
-																				<object class="NSMenuItem" id="846565375">
-																					<reference key="NSMenu" ref="759074717"/>
-																					<string key="NSTitle">File Name</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSKeyPathExpression" key="NSRepObject">
-																						<int key="NSExpressionType">3</int>
-																						<string key="NSSelectorName">valueForKey:</string>
-																						<reference key="NSOperand" ref="1030886767"/>
-																						<array class="NSMutableArray" key="NSArguments">
-																							<object class="NSKeyPathSpecifierExpression">
-																								<int key="NSExpressionType">10</int>
-																								<string key="NSKeyPath">filename</string>
-																							</object>
-																						</array>
-																					</object>
-																					<reference key="NSTarget" ref="412547117"/>
-																				</object>
-																				<object class="NSMenuItem" id="391995907">
-																					<reference key="NSMenu" ref="759074717"/>
-																					<string key="NSTitle">Function / Method Name</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSKeyPathExpression" key="NSRepObject">
-																						<int key="NSExpressionType">3</int>
-																						<string key="NSSelectorName">valueForKey:</string>
-																						<reference key="NSOperand" ref="1030886767"/>
-																						<array class="NSMutableArray" key="NSArguments">
-																							<object class="NSKeyPathSpecifierExpression">
-																								<int key="NSExpressionType">10</int>
-																								<string key="NSKeyPath">functionName</string>
-																							</object>
-																						</array>
-																					</object>
-																					<reference key="NSTarget" ref="412547117"/>
-																				</object>
-																			</array>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="745391060">
-																	<reference key="NSNextResponder" ref="569675527"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{122, 3}, {99, 19}}</string>
-																	<reference key="NSSuperview" ref="569675527"/>
-																	<reference key="NSNextKeyView" ref="235140985"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="324510646">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<integer value="99" key="NSRepresentedObject"/>
-																		<reference key="NSControlView" ref="745391060"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="158030715">
-																			<reference key="NSMenu" ref="298046528"/>
-																			<string key="NSTitle">contains</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<integer value="99" key="NSRepObject"/>
-																			<reference key="NSTarget" ref="324510646"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="298046528">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="158030715"/>
-																				<object class="NSMenuItem" id="637184669">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">begins with</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="8" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																				<object class="NSMenuItem" id="1066770911">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">ends with</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="9" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																				<object class="NSMenuItem" id="516914548">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">is</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="4" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																				<object class="NSMenuItem" id="469243200">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">is not</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="5" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																				<object class="NSMenuItem" id="210569817">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">matches</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="6" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																				<object class="NSMenuItem" id="803680276">
-																					<reference key="NSMenu" ref="298046528"/>
-																					<string key="NSTitle">is like</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="7" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="324510646"/>
-																				</object>
-																			</array>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSTextField" id="235140985">
-																	<reference key="NSNextResponder" ref="569675527"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{227, 4}, {160, 18}}</string>
-																	<reference key="NSSuperview" ref="569675527"/>
-																	<reference key="NSNextKeyView" ref="1021510370"/>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSTextFieldCell" key="NSCell">
-																		<int key="NSCellFlags">342884416</int>
-																		<int key="NSCellFlags2">4326400</int>
-																		<string key="NSContents"/>
-																		<reference key="NSSupport" ref="26"/>
-																		<reference key="NSControlView" ref="235140985"/>
-																		<bool key="NSDrawsBackground">YES</bool>
-																		<reference key="NSBackgroundColor" ref="186242573"/>
-																		<reference key="NSTextColor" ref="474791504"/>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-															</array>
-															<string key="NSFrame">{{0, 50}, {478, 25}}</string>
-															<reference key="NSSuperview" ref="436362337"/>
-															<reference key="NSNextKeyView" ref="228875584"/>
-															<int key="NSRuleRowIndex">2</int>
-															<int key="NSRuleIndentation">1</int>
-															<reference key="NSContainingRuleEditorView" ref="244222353"/>
-															<nil key="NSRuleBackgroundColor"/>
-															<array class="NSMutableArray" key="NSRuleOptionViews">
-																<reference ref="228875584"/>
-																<reference ref="745391060"/>
-																<reference ref="235140985"/>
-															</array>
-															<int key="NSRuleOptionFrames.count">3</int>
-															<string key="NSRuleOptionFrames.0">{{37, 3}, {79, 19}}</string>
-															<string key="NSRuleOptionFrames.1">{{122, 3}, {99, 19}}</string>
-															<string key="NSRuleOptionFrames.2">{{227, 4}, {160, 18}}</string>
-															<array class="NSMutableArray" key="NSRuleOptionItems">
-																<dictionary class="NSMutableDictionary" id="501840107">
-																	<integer value="1" key="depth"/>
-																	<object class="NSPredicateEditorRowTemplate" key="pattern" id="338376168">
-																		<int key="NSPredicateTemplateType">1</int>
-																		<int key="NSPredicateTemplateOptions">1</int>
-																		<int key="NSPredicateTemplateModifier">0</int>
-																		<int key="NSPredicateTemplateLeftAttributeType">0</int>
-																		<int key="NSPredicateTemplateRightAttributeType">700</int>
-																		<array key="NSPredicateTemplateViews">
-																			<reference ref="228875584"/>
-																			<reference ref="745391060"/>
-																			<reference ref="235140985"/>
-																		</array>
-																		<bool key="NSPredicateTemplateLeftIsWildcard">NO</bool>
-																		<bool key="NSPredicateTemplateRightIsWildcard">YES</bool>
-																	</object>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="739106909">
-																	<integer value="2" key="depth"/>
-																	<reference key="pattern" ref="338376168"/>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="666344030">
-																	<integer value="3" key="depth"/>
-																	<reference key="pattern" ref="338376168"/>
-																</dictionary>
-															</array>
-															<int key="NSRuleOptionInitialFrames.count">3</int>
-															<string key="NSRuleOptionInitialFrames.0">{{37, 3}, {79, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.1">{{122, 3}, {99, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.2">{{227, 4}, {160, 18}}</string>
-															<reference key="NSRuleOptionAddButton" ref="814685270"/>
-															<reference key="NSRuleOptionSubtractButton" ref="1021510370"/>
-															<int key="NSRuleOptionRowType">0</int>
-															<int key="NSRuleOptionPlusButtonRowType">0</int>
-															<bool key="NSRuleOptionEditable">YES</bool>
-														</object>
-														<object class="NSRuleEditorViewSliceRow" id="647529487">
-															<reference key="NSNextResponder" ref="436362337"/>
-															<int key="NSvFlags">290</int>
-															<array class="NSMutableArray" key="NSSubviews">
-																<object class="NSButton" id="985434722">
-																	<reference key="NSNextResponder" ref="647529487"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{450, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="647529487"/>
-																	<reference key="NSNextKeyView" ref="244222353"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">+</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">add</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="985434722"/>
-																		<string key="NSAction">_addOption:</string>
-																		<reference key="NSTarget" ref="647529487"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSButton" id="941079382">
-																	<reference key="NSNextResponder" ref="647529487"/>
-																	<int key="NSvFlags">257</int>
-																	<string key="NSFrame">{{430, 4}, {18, 18}}</string>
-																	<reference key="NSSuperview" ref="647529487"/>
-																	<reference key="NSNextKeyView" ref="985434722"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSRuleEditorButtonCell" key="NSCell">
-																		<int key="NSCellFlags">67108864</int>
-																		<int key="NSCellFlags2">134348800</int>
-																		<string key="NSContents">-</string>
-																		<reference key="NSSupport" ref="29"/>
-																		<array class="NSMutableArray" key="NSAccessibilityOverriddenAttributes">
-																			<dictionary class="NSMutableDictionary">
-																				<string key="AXDescription">remove</string>
-																				<integer value="1" key="NSAccessibilityEncodedAttributesValueType"/>
-																			</dictionary>
-																		</array>
-																		<reference key="NSControlView" ref="941079382"/>
-																		<string key="NSAction">_deleteOption:</string>
-																		<reference key="NSTarget" ref="647529487"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="28"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="645762441">
-																	<reference key="NSNextResponder" ref="647529487"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{37, 3}, {94, 19}}</string>
-																	<reference key="NSSuperview" ref="647529487"/>
-																	<reference key="NSNextKeyView" ref="589134369"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="253773574">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<object class="NSKeyPathExpression" key="NSRepresentedObject" id="241816622">
-																			<int key="NSExpressionType">3</int>
-																			<string key="NSSelectorName">valueForKey:</string>
-																			<reference key="NSOperand" ref="1030886767"/>
-																			<array class="NSMutableArray" key="NSArguments">
-																				<object class="NSKeyPathSpecifierExpression">
-																					<int key="NSExpressionType">10</int>
-																					<string key="NSKeyPath">level</string>
-																				</object>
-																			</array>
-																		</object>
-																		<reference key="NSControlView" ref="645762441"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="340355613">
-																			<reference key="NSMenu" ref="355445859"/>
-																			<string key="NSTitle">Log Level</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<reference key="NSRepObject" ref="241816622"/>
-																			<reference key="NSTarget" ref="253773574"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="355445859">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="340355613"/>
-																				<object class="NSMenuItem" id="1006264860">
-																					<reference key="NSMenu" ref="355445859"/>
-																					<string key="NSTitle">Line Number</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<object class="NSKeyPathExpression" key="NSRepObject">
-																						<int key="NSExpressionType">3</int>
-																						<string key="NSSelectorName">valueForKey:</string>
-																						<reference key="NSOperand" ref="1030886767"/>
-																						<array class="NSMutableArray" key="NSArguments">
-																							<object class="NSKeyPathSpecifierExpression">
-																								<int key="NSExpressionType">10</int>
-																								<string key="NSKeyPath">lineNumber</string>
-																							</object>
-																						</array>
-																					</object>
-																					<reference key="NSTarget" ref="253773574"/>
-																				</object>
-																			</array>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSPopUpButton" id="589134369">
-																	<reference key="NSNextResponder" ref="647529487"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{137, 3}, {99, 19}}</string>
-																	<reference key="NSSuperview" ref="647529487"/>
-																	<reference key="NSNextKeyView" ref="537107283"/>
-																	<int key="NSTag">-1</int>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSPopUpButtonCell" key="NSCell" id="622511076">
-																		<int key="NSCellFlags">67108928</int>
-																		<int key="NSCellFlags2">4196352</int>
-																		<reference key="NSSupport" ref="26"/>
-																		<integer value="4" key="NSRepresentedObject"/>
-																		<reference key="NSControlView" ref="589134369"/>
-																		<int key="NSButtonFlags">-2038284288</int>
-																		<int key="NSButtonFlags2">36</int>
-																		<reference key="NSAlternateImage" ref="781454291"/>
-																		<string key="NSKeyEquivalent"/>
-																		<int key="NSPeriodicDelay">400</int>
-																		<int key="NSPeriodicInterval">75</int>
-																		<object class="NSMenuItem" key="NSMenuItem" id="434776007">
-																			<reference key="NSMenu" ref="37608884"/>
-																			<string key="NSTitle">is</string>
-																			<string key="NSKeyEquiv"/>
-																			<int key="NSKeyEquivModMask">1048576</int>
-																			<int key="NSMnemonicLoc">2147483647</int>
-																			<int key="NSState">1</int>
-																			<reference key="NSOnImage" ref="13266356"/>
-																			<reference key="NSMixedImage" ref="1054000876"/>
-																			<string key="NSAction">_popUpItemAction:</string>
-																			<integer value="4" key="NSRepObject"/>
-																			<reference key="NSTarget" ref="622511076"/>
-																		</object>
-																		<bool key="NSMenuItemRespectAlignment">YES</bool>
-																		<object class="NSMenu" key="NSMenu" id="37608884">
-																			<string key="NSTitle"/>
-																			<array class="NSMutableArray" key="NSMenuItems">
-																				<reference ref="434776007"/>
-																				<object class="NSMenuItem" id="749875840">
-																					<reference key="NSMenu" ref="37608884"/>
-																					<string key="NSTitle">is not</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="5" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="622511076"/>
-																				</object>
-																				<object class="NSMenuItem" id="279679582">
-																					<reference key="NSMenu" ref="37608884"/>
-																					<string key="NSTitle">is greater than or equal to</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="3" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="622511076"/>
-																				</object>
-																				<object class="NSMenuItem" id="394110264">
-																					<reference key="NSMenu" ref="37608884"/>
-																					<string key="NSTitle">is less than or equal to</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="1" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="622511076"/>
-																				</object>
-																				<object class="NSMenuItem" id="813620577">
-																					<reference key="NSMenu" ref="37608884"/>
-																					<string key="NSTitle">is less than</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="0" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="622511076"/>
-																				</object>
-																				<object class="NSMenuItem" id="138011791">
-																					<reference key="NSMenu" ref="37608884"/>
-																					<string key="NSTitle">is greater than</string>
-																					<string key="NSKeyEquiv"/>
-																					<int key="NSKeyEquivModMask">1048576</int>
-																					<int key="NSMnemonicLoc">2147483647</int>
-																					<reference key="NSOnImage" ref="13266356"/>
-																					<reference key="NSMixedImage" ref="1054000876"/>
-																					<string key="NSAction">_popUpItemAction:</string>
-																					<integer value="2" key="NSRepObject"/>
-																					<reference key="NSTarget" ref="622511076"/>
-																				</object>
-																			</array>
-																		</object>
-																		<int key="NSPreferredEdge">3</int>
-																		<bool key="NSUsesItemFromMenu">YES</bool>
-																		<bool key="NSAltersState">YES</bool>
-																		<int key="NSArrowPosition">2</int>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-																<object class="NSTextField" id="537107283">
-																	<reference key="NSNextResponder" ref="647529487"/>
-																	<int key="NSvFlags">256</int>
-																	<string key="NSFrame">{{242, 4}, {25, 18}}</string>
-																	<reference key="NSSuperview" ref="647529487"/>
-																	<reference key="NSNextKeyView" ref="941079382"/>
-																	<bool key="NSEnabled">YES</bool>
-																	<object class="NSTextFieldCell" key="NSCell">
-																		<int key="NSCellFlags">342884416</int>
-																		<int key="NSCellFlags2">4326400</int>
-																		<string key="NSContents"/>
-																		<reference key="NSSupport" ref="26"/>
-																		<reference key="NSControlView" ref="537107283"/>
-																		<bool key="NSDrawsBackground">YES</bool>
-																		<reference key="NSBackgroundColor" ref="186242573"/>
-																		<reference key="NSTextColor" ref="474791504"/>
-																	</object>
-																	<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-																</object>
-															</array>
-															<string key="NSFrame">{{0, 75}, {478, 25}}</string>
-															<reference key="NSSuperview" ref="436362337"/>
-															<reference key="NSNextKeyView" ref="645762441"/>
-															<int key="NSRuleRowIndex">3</int>
-															<int key="NSRuleIndentation">1</int>
-															<reference key="NSContainingRuleEditorView" ref="244222353"/>
-															<nil key="NSRuleBackgroundColor"/>
-															<array class="NSMutableArray" key="NSRuleOptionViews">
-																<reference ref="645762441"/>
-																<reference ref="589134369"/>
-																<reference ref="537107283"/>
-															</array>
-															<int key="NSRuleOptionFrames.count">3</int>
-															<string key="NSRuleOptionFrames.0">{{37, 3}, {94, 19}}</string>
-															<string key="NSRuleOptionFrames.1">{{137, 3}, {99, 19}}</string>
-															<string key="NSRuleOptionFrames.2">{{242, 4}, {25, 18}}</string>
-															<array class="NSMutableArray" key="NSRuleOptionItems">
-																<dictionary class="NSMutableDictionary" id="942797197">
-																	<integer value="1" key="depth"/>
-																	<object class="NSPredicateEditorRowTemplate" key="pattern" id="447301357">
-																		<int key="NSPredicateTemplateType">1</int>
-																		<int key="NSPredicateTemplateOptions">0</int>
-																		<int key="NSPredicateTemplateModifier">0</int>
-																		<int key="NSPredicateTemplateLeftAttributeType">0</int>
-																		<int key="NSPredicateTemplateRightAttributeType">300</int>
-																		<array key="NSPredicateTemplateViews">
-																			<reference ref="645762441"/>
-																			<reference ref="589134369"/>
-																			<reference ref="537107283"/>
-																		</array>
-																		<bool key="NSPredicateTemplateLeftIsWildcard">NO</bool>
-																		<bool key="NSPredicateTemplateRightIsWildcard">YES</bool>
-																	</object>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="313291271">
-																	<integer value="2" key="depth"/>
-																	<reference key="pattern" ref="447301357"/>
-																</dictionary>
-																<dictionary class="NSMutableDictionary" id="357149601">
-																	<integer value="3" key="depth"/>
-																	<reference key="pattern" ref="447301357"/>
-																</dictionary>
-															</array>
-															<int key="NSRuleOptionInitialFrames.count">3</int>
-															<string key="NSRuleOptionInitialFrames.0">{{37, 3}, {94, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.1">{{137, 3}, {99, 19}}</string>
-															<string key="NSRuleOptionInitialFrames.2">{{242, 4}, {25, 18}}</string>
-															<reference key="NSRuleOptionAddButton" ref="985434722"/>
-															<reference key="NSRuleOptionSubtractButton" ref="941079382"/>
-															<int key="NSRuleOptionRowType">0</int>
-															<int key="NSRuleOptionPlusButtonRowType">0</int>
-															<bool key="NSRuleOptionEditable">YES</bool>
-														</object>
-													</array>
-													<string key="NSFrame">{{1, 1}, {478, 160}}</string>
-													<reference key="NSSuperview" ref="244222353"/>
-													<reference key="NSNextKeyView" ref="654456339"/>
-												</object>
-											</array>
-											<set class="NSMutableSet" key="NSDragTypes">
-												<string>NSRuleEditorItemPBoardType</string>
-											</set>
-											<string key="NSFrameSize">{480, 160}</string>
-											<reference key="NSSuperview" ref="595262929"/>
-											<reference key="NSNextKeyView" ref="436362337"/>
-											<bool key="NSEnabled">YES</bool>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<double key="NSRuleEditorAlignmentGridWidth">75</double>
-											<double key="NSRuleEditorSliceHeight">25</double>
-											<bool key="NSRuleEditorEditable">YES</bool>
-											<bool key="NSRuleEditorAllowsEmptyCompoundRows">NO</bool>
-											<bool key="NSRuleEditorDisallowEmpty">YES</bool>
-											<int key="NSRuleEditorNestingMode">3</int>
-											<string key="NSRuleEditorRowTypeKeyPath">rowType</string>
-											<string key="NSRuleEditorSubrowsArrayKeyPath">subrows</string>
-											<string key="NSRuleEditorItemsKeyPath">criteria</string>
-											<string key="NSRuleEditorValuesKeyPath">displayValues</string>
-											<string key="NSRuleEditorBoundArrayKeyPath">boundArray</string>
-											<string key="NSRuleEditorRowClass">NSMutableDictionary</string>
-											<reference key="NSRuleEditorSlicesHolder" ref="436362337"/>
-											<reference key="NSRuleEditorDelegate"/>
-											<object class="_NSRuleEditorViewUnboundRowHolder" key="NSRuleEditorBoundArrayOwner">
-												<array class="NSMutableArray" key="NSBoundArray">
-													<dictionary class="NSMutableDictionary">
-														<array class="NSMutableArray" key="criteria">
-															<reference ref="831541601"/>
-															<reference ref="871628778"/>
-														</array>
-														<array class="NSMutableArray" key="displayValues">
-															<reference ref="407208618"/>
-															<reference ref="873844501"/>
-														</array>
-														<integer value="1" key="rowType"/>
-														<array class="NSMutableArray" key="subrows">
-															<dictionary class="NSMutableDictionary">
-																<array class="NSMutableArray" key="criteria">
-																	<reference ref="458174286"/>
-																	<reference ref="787394286"/>
-																	<reference ref="331677407"/>
-																</array>
-																<array class="NSMutableArray" key="displayValues">
-																	<reference ref="952908386"/>
-																	<reference ref="719560781"/>
-																	<reference ref="606793315"/>
-																</array>
-																<integer value="0" key="rowType"/>
-																<array class="NSMutableArray" key="subrows"/>
-															</dictionary>
-															<dictionary class="NSMutableDictionary">
-																<array class="NSMutableArray" key="criteria">
-																	<reference ref="501840107"/>
-																	<reference ref="739106909"/>
-																	<reference ref="666344030"/>
-																</array>
-																<array class="NSMutableArray" key="displayValues">
-																	<reference ref="228875584"/>
-																	<reference ref="745391060"/>
-																	<reference ref="235140985"/>
-																</array>
-																<integer value="0" key="rowType"/>
-																<array class="NSMutableArray" key="subrows"/>
-															</dictionary>
-															<dictionary class="NSMutableDictionary">
-																<array class="NSMutableArray" key="criteria">
-																	<reference ref="942797197"/>
-																	<reference ref="313291271"/>
-																	<reference ref="357149601"/>
-																</array>
-																<array class="NSMutableArray" key="displayValues">
-																	<reference ref="645762441"/>
-																	<reference ref="589134369"/>
-																	<reference ref="537107283"/>
-																</array>
-																<integer value="0" key="rowType"/>
-																<array class="NSMutableArray" key="subrows"/>
-															</dictionary>
-														</array>
-													</dictionary>
-												</array>
-											</object>
-											<array class="NSMutableArray" key="NSRuleEditorSlices">
-												<reference ref="654456339"/>
-												<reference ref="532891414"/>
-												<reference ref="569675527"/>
-												<reference ref="647529487"/>
-											</array>
-											<array key="NSPredicateTemplates">
-												<reference ref="996633552"/>
-												<reference ref="216723110"/>
-												<reference ref="338376168"/>
-												<reference ref="447301357"/>
-											</array>
-											<nil key="NSPredicateEditorPredicate"/>
-										</object>
-									</array>
-									<string key="NSFrame">{{1, 1}, {480, 160}}</string>
-									<reference key="NSSuperview" ref="45475269"/>
-									<reference key="NSNextKeyView" ref="244222353"/>
-									<reference key="NSDocView" ref="244222353"/>
-									<object class="NSColor" key="NSBGColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC45MTAwMDAwMjYyAA</bytes>
-									</object>
-									<int key="NScvFlags">4</int>
-								</object>
-								<object class="NSScroller" id="1039326813">
-									<reference key="NSNextResponder" ref="45475269"/>
-									<int key="NSvFlags">-2147483392</int>
-									<string key="NSFrame">{{466, 1}, {15, 146}}</string>
-									<reference key="NSSuperview" ref="45475269"/>
-									<reference key="NSNextKeyView" ref="363399671"/>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<reference key="NSTarget" ref="45475269"/>
-									<string key="NSAction">_doScroller:</string>
-									<double key="NSPercent">0.97333335876464844</double>
-								</object>
-								<object class="NSScroller" id="283792662">
-									<reference key="NSNextResponder" ref="45475269"/>
-									<int key="NSvFlags">-2147483392</int>
-									<string key="NSFrame">{{-100, -100}, {360, 15}}</string>
-									<reference key="NSSuperview" ref="45475269"/>
-									<reference key="NSNextKeyView" ref="595262929"/>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-									<int key="NSsFlags">1</int>
-									<reference key="NSTarget" ref="45475269"/>
-									<string key="NSAction">_doScroller:</string>
-								</object>
-							</array>
-							<string key="NSFrame">{{-1, 60}, {482, 162}}</string>
-							<reference key="NSSuperview" ref="825133058"/>
-							<reference key="NSNextKeyView" ref="595262929"/>
-							<int key="NSsFlags">133650</int>
-							<reference key="NSVScroller" ref="1039326813"/>
-							<reference key="NSHScroller" ref="283792662"/>
-							<reference key="NSContentView" ref="595262929"/>
-							<double key="NSMinMagnification">0.25</double>
-							<double key="NSMaxMagnification">4</double>
-							<double key="NSMagnification">1</double>
-						</object>
-						<object class="NSButton" id="473480621">
-							<reference key="NSNextResponder" ref="825133058"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{370, 12}, {96, 32}}</string>
-							<reference key="NSSuperview" ref="825133058"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="1010842736">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">OK</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="473480621"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="363399671">
-							<reference key="NSNextResponder" ref="825133058"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{274, 12}, {96, 32}}</string>
-							<reference key="NSSuperview" ref="825133058"/>
-							<reference key="NSNextKeyView" ref="473480621"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="566838678">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Cancel</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="363399671"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="979771143">
-							<reference key="NSNextResponder" ref="825133058"/>
-							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{102, 231}, {358, 22}}</string>
-							<reference key="NSSuperview" ref="825133058"/>
-							<reference key="NSNextKeyView" ref="45475269"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="801978664">
-								<int key="NSCellFlags">-1804599231</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="4432246"/>
-								<string key="NSPlaceholderString">filter name</string>
-								<reference key="NSControlView" ref="979771143"/>
-								<bool key="NSDrawsBackground">YES</bool>
-								<reference key="NSBackgroundColor" ref="186242573"/>
-								<object class="NSColor" key="NSTextColor" id="1014661679">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textColor</string>
-									<reference key="NSColor" ref="745683106"/>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="763554720">
-							<reference key="NSNextResponder" ref="825133058"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 233}, {81, 17}}</string>
-							<reference key="NSSuperview" ref="825133058"/>
-							<reference key="NSNextKeyView" ref="979771143"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="450943096">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">Filter Name:</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="763554720"/>
-								<object class="NSColor" key="NSBackgroundColor" id="580121781">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlColor</string>
-									<reference key="NSColor" ref="362555436"/>
-								</object>
-								<reference key="NSTextColor" ref="474791504"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{480, 270}</string>
-					<reference key="NSNextKeyView" ref="763554720"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
-				<string key="NSMinSize">{400, 222}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSWindowTemplate" id="930602132">
-				<int key="NSWindowStyleMask">257</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{183, 448}, {480, 111}}</string>
-				<int key="NSWTFlags">1685586944</int>
-				<string key="NSWindowTitle">New Mark</string>
-				<string key="NSWindowClass">NSWindow</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<object class="NSView" key="NSWindowView" id="279634916">
-					<nil key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSTextField" id="183329842">
-							<reference key="NSNextResponder" ref="279634916"/>
-							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{94, 72}, {366, 22}}</string>
-							<reference key="NSSuperview" ref="279634916"/>
-							<reference key="NSNextKeyView" ref="726699141"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="562290842">
-								<int key="NSCellFlags">-1804599231</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="4432246"/>
-								<string key="NSPlaceholderString">Mark title</string>
-								<reference key="NSControlView" ref="183329842"/>
-								<bool key="NSDrawsBackground">YES</bool>
-								<reference key="NSBackgroundColor" ref="186242573"/>
-								<reference key="NSTextColor" ref="1014661679"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="932005013">
-							<reference key="NSNextResponder" ref="279634916"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 74}, {72, 17}}</string>
-							<reference key="NSSuperview" ref="279634916"/>
-							<reference key="NSNextKeyView" ref="183329842"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="226479939">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272630784</int>
-								<string key="NSContents">New mark:</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="932005013"/>
-								<reference key="NSBackgroundColor" ref="580121781"/>
-								<reference key="NSTextColor" ref="474791504"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="807984468">
-							<reference key="NSNextResponder" ref="279634916"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{370, 12}, {96, 32}}</string>
-							<reference key="NSSuperview" ref="279634916"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="538657820">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">OK</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="807984468"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="726699141">
-							<reference key="NSNextResponder" ref="279634916"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{269, 12}, {96, 32}}</string>
-							<reference key="NSSuperview" ref="279634916"/>
-							<reference key="NSNextKeyView" ref="807984468"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="141491742">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">Cancel</string>
-								<reference key="NSSupport" ref="4432246"/>
-								<reference key="NSControlView" ref="726699141"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">Gw</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{480, 111}</string>
-					<reference key="NSNextKeyView" ref="932005013"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSArrayController" id="78795738">
-				<array class="NSMutableArray" key="NSDeclaredKeys">
-					<string>filters</string>
-					<string>title</string>
-					<string>uid</string>
-				</array>
-				<bool key="NSEditable">YES</bool>
-				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
-				<bool key="NSAvoidsEmptySelection">YES</bool>
-				<bool key="NSPreservesSelection">YES</bool>
-				<bool key="NSSelectsInsertedObjects">YES</bool>
-				<bool key="NSFilterRestrictsInsertion">YES</bool>
-				<bool key="NSClearsFilterPredicateOnInsertion">YES</bool>
-				<bool key="NSAutomaticallyRearrangesObjects">YES</bool>
-			</object>
-			<object class="NSArrayController" id="923242454">
-				<array class="NSMutableArray" key="NSDeclaredKeys">
-					<string>title</string>
-					<string>predicate</string>
-					<string>uid</string>
-				</array>
-				<bool key="NSEditable">YES</bool>
-				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
-				<bool key="NSAvoidsEmptySelection">YES</bool>
-				<bool key="NSPreservesSelection">YES</bool>
-				<bool key="NSSelectsInsertedObjects">YES</bool>
-				<bool key="NSFilterRestrictsInsertion">YES</bool>
-				<bool key="NSClearsFilterPredicateOnInsertion">YES</bool>
-				<bool key="NSAutomaticallyRearrangesObjects">YES</bool>
-			</object>
-			<object class="NSUserDefaultsController" id="324114734">
-				<bool key="NSSharedInstance">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">logTable</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="522308002"/>
-					</object>
-					<int key="connectionID">535</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">addFilter:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="983099424"/>
-					</object>
-					<int key="connectionID">701</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterListController</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="923242454"/>
-					</object>
-					<int key="connectionID">702</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="972006081"/>
-					</object>
-					<int key="connectionID">813</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterEditorWindow</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="585219689"/>
-					</object>
-					<int key="connectionID">814</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterEditor</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="244222353"/>
-					</object>
-					<int key="connectionID">815</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">validateFilterEdition:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="473480621"/>
-					</object>
-					<int key="connectionID">816</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">cancelFilterEdition:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="363399671"/>
-					</object>
-					<int key="connectionID">817</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterName</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="979771143"/>
-					</object>
-					<int key="connectionID">818</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterTable</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="150938961"/>
-					</object>
-					<int key="connectionID">893</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">quickFilter</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="622971220"/>
-					</object>
-					<int key="connectionID">912</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="267491286"/>
-					</object>
-					<int key="connectionID">916</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="779670545"/>
-					</object>
-					<int key="connectionID">917</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="1063259389"/>
-					</object>
-					<int key="connectionID">918</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="941498601"/>
-					</object>
-					<int key="connectionID">919</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="599580337"/>
-					</object>
-					<int key="connectionID">920</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="318690278"/>
-					</object>
-					<int key="connectionID">921</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">deleteSelectedFilters:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="219283996"/>
-					</object>
-					<int key="connectionID">926</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">buttonBar</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="1007791563"/>
-					</object>
-					<int key="connectionID">934</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterLevel:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="443333885"/>
-					</object>
-					<int key="connectionID">937</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">selectQuickFilterTag:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="751047399"/>
-					</object>
-					<int key="connectionID">940</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterSetsTable</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="441275434"/>
-					</object>
-					<int key="connectionID">972</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterSetsListController</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="78795738"/>
-					</object>
-					<int key="connectionID">973</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">addFilterSet:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="179564853"/>
-					</object>
-					<int key="connectionID">974</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">deleteSelectedFilterSet:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="206027241"/>
-					</object>
-					<int key="connectionID">975</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">resetQuickFilter:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="1071402364"/>
-					</object>
-					<int key="connectionID">1099</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">openDetailsWindow:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="895409037"/>
-					</object>
-					<int key="connectionID">1100</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">markTitleWindow</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="930602132"/>
-					</object>
-					<int key="connectionID">1160</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">markTitleField</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="183329842"/>
-					</object>
-					<int key="connectionID">1161</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">validateAddMark:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="807984468"/>
-					</object>
-					<int key="connectionID">1162</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">cancelAddMark:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="726699141"/>
-					</object>
-					<int key="connectionID">1163</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">showFunctionNamesButton</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="692175765"/>
-					</object>
-					<int key="connectionID">1221</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">createNewFilterFromQuickFilter:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="796904695"/>
-					</object>
-					<int key="connectionID">1248</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">quickFilterTextField</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="26638440"/>
-					</object>
-					<int key="connectionID">1301</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">clearAllLogs:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="859424117"/>
-					</object>
-					<int key="connectionID">1442</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">clearCurrentLog:</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="241913815"/>
-					</object>
-					<int key="connectionID">1443</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">splitView</string>
-						<reference key="source" ref="1021"/>
-						<reference key="destination" ref="252816051"/>
-					</object>
-					<int key="connectionID">1444</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">showPreferences:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="1009168716"/>
-					</object>
-					<int key="connectionID">1311</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">openDocument:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="999087205"/>
-					</object>
-					<int key="connectionID">1328</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">saveDocument:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="958014623"/>
-					</object>
-					<int key="connectionID">1329</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">saveDocumentTo:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="1072918009"/>
-					</object>
-					<int key="connectionID">1331</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="972006081"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">913</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="150938961"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">935</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="150938961"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">998</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: arrangedObjects.title</string>
-						<reference key="source" ref="34494719"/>
-						<reference key="destination" ref="923242454"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="34494719"/>
-							<reference key="NSDestination" ref="923242454"/>
-							<string key="NSLabel">value: arrangedObjects.title</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">arrangedObjects.title</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSConditionallySetsEditable"/>
-								<boolean value="NO" key="NSCreatesSortDescriptor"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">981</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">headerTitle: selection.title</string>
-						<reference key="source" ref="34494719"/>
-						<reference key="destination" ref="78795738"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="34494719"/>
-							<reference key="NSDestination" ref="78795738"/>
-							<string key="NSLabel">headerTitle: selection.title</string>
-							<string key="NSBinding">headerTitle</string>
-							<string key="NSKeyPath">selection.title</string>
-							<dictionary key="NSOptions">
-								<string key="NSNoSelectionPlaceholder">No Selection</string>
-								<string key="NSNullPlaceholder">No Selection</string>
-								<string key="NSValueTransformerName">FilterColumnHeader</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1191</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="522308002"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">941</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="522308002"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">942</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: info</string>
-						<reference key="source" ref="984409547"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="984409547"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">value: info</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">info</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSNullPlaceholder</string>
-								<string key="NS.object.0">Logs from unidentified source</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">859</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: selectedObjects</string>
-						<reference key="source" ref="219283996"/>
-						<reference key="destination" ref="923242454"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="219283996"/>
-							<reference key="NSDestination" ref="923242454"/>
-							<string key="NSLabel">enabled: selectedObjects</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">selectedObjects</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">CanDeleteFilterSelection</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">985</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">sortDescriptors: delegate.filtersSortDescriptors</string>
-						<reference key="source" ref="923242454"/>
-						<reference key="destination" ref="1050"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="923242454"/>
-							<reference key="NSDestination" ref="1050"/>
-							<string key="NSLabel">sortDescriptors: delegate.filtersSortDescriptors</string>
-							<string key="NSBinding">sortDescriptors</string>
-							<string key="NSKeyPath">delegate.filtersSortDescriptors</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">990</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentArray: selection.filters</string>
-						<reference key="source" ref="923242454"/>
-						<reference key="destination" ref="78795738"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="923242454"/>
-							<reference key="NSDestination" ref="78795738"/>
-							<string key="NSLabel">contentArray: selection.filters</string>
-							<string key="NSBinding">contentArray</string>
-							<string key="NSKeyPath">selection.filters</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">996</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: logLevel</string>
-						<reference key="source" ref="622971220"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="622971220"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">selectedIndex: logLevel</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">logLevel</string>
-							<dictionary key="NSOptions">
-								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
-								<boolean value="NO" key="NSConditionallySetsEnabled"/>
-								<boolean value="NO" key="NSRaisesForNotApplicableKeys"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">901</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: selectedObjects</string>
-						<reference key="source" ref="206027241"/>
-						<reference key="destination" ref="78795738"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="206027241"/>
-							<reference key="NSDestination" ref="78795738"/>
-							<string key="NSLabel">enabled: selectedObjects</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">selectedObjects</string>
-							<dictionary key="NSOptions">
-								<integer value="0" key="NSNoSelectionPlaceholder"/>
-								<integer value="0" key="NSNotApplicablePlaceholder"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-								<string key="NSValueTransformerName">CanDeleteFilterSelection</string>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">976</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="441275434"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">971</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="441275434"/>
-						<reference key="destination" ref="1021"/>
-					</object>
-					<int key="connectionID">997</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: arrangedObjects.title</string>
-						<reference key="source" ref="612119745"/>
-						<reference key="destination" ref="78795738"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="612119745"/>
-							<reference key="NSDestination" ref="78795738"/>
-							<string key="NSLabel">value: arrangedObjects.title</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">arrangedObjects.title</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSConditionallySetsEditable"/>
-								<boolean value="NO" key="NSCreatesSortDescriptor"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">980</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentArray: delegate.filterSets</string>
-						<reference key="source" ref="78795738"/>
-						<reference key="destination" ref="1050"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="78795738"/>
-							<reference key="NSDestination" ref="1050"/>
-							<string key="NSLabel">contentArray: delegate.filterSets</string>
-							<string key="NSBinding">contentArray</string>
-							<string key="NSKeyPath">delegate.filterSets</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">969</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">sortDescriptors: delegate.filtersSortDescriptors</string>
-						<reference key="source" ref="78795738"/>
-						<reference key="destination" ref="1050"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="78795738"/>
-							<reference key="NSDestination" ref="1050"/>
-							<string key="NSLabel">sortDescriptors: delegate.filtersSortDescriptors</string>
-							<string key="NSBinding">sortDescriptors</string>
-							<string key="NSKeyPath">delegate.filtersSortDescriptors</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">983</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: hasQuickFilter</string>
-						<reference key="source" ref="1071402364"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1071402364"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">enabled: hasQuickFilter</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">hasQuickFilter</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1098</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: showFunctionNames</string>
-						<reference key="source" ref="692175765"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="692175765"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">value: showFunctionNames</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">showFunctionNames</string>
-							<dictionary key="NSOptions">
-								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
-								<boolean value="NO" key="NSConditionallySetsEnabled"/>
-								<integer value="0" key="NSNullPlaceholder"/>
-								<boolean value="NO" key="NSRaisesForNotApplicableKeys"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1239</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: hasQuickFilter</string>
-						<reference key="source" ref="796904695"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="796904695"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">enabled: hasQuickFilter</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">hasQuickFilter</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1247</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: filterString</string>
-						<reference key="source" ref="490457310"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="490457310"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">value: filterString</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">filterString</string>
-							<dictionary key="NSOptions">
-								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
-								<boolean value="YES" key="NSAlwaysPresentsApplicationModalAlerts"/>
-								<boolean value="NO" key="NSConditionallySetsEditable"/>
-								<boolean value="YES" key="NSContinuouslyUpdatesValue"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1308</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentValues: document.attachedLogsPopupNames</string>
-						<reference key="source" ref="336153473"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector" id="769970158">
-							<reference key="NSSource" ref="336153473"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">contentValues: document.attachedLogsPopupNames</string>
-							<string key="NSBinding">contentValues</string>
-							<string key="NSKeyPath">document.attachedLogsPopupNames</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1419</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">selectedIndex: document.indexOfCurrentVisibleLog</string>
-						<reference key="source" ref="336153473"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="336153473"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">selectedIndex: document.indexOfCurrentVisibleLog</string>
-							<string key="NSBinding">selectedIndex</string>
-							<string key="NSKeyPath">document.indexOfCurrentVisibleLog</string>
-							<dictionary key="NSOptions">
-								<boolean value="NO" key="NSAllowsEditingMultipleValuesSelection"/>
-								<real value="0.0" key="NSNoSelectionPlaceholder"/>
-								<real value="0.0" key="NSNullPlaceholder"/>
-							</dictionary>
-							<reference key="NSPreviousConnector" ref="769970158"/>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1424</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: shouldEnableRunsPopup</string>
-						<reference key="source" ref="336153473"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="336153473"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">enabled: shouldEnableRunsPopup</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">shouldEnableRunsPopup</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1430</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: canClearCurrentLog</string>
-						<reference key="source" ref="241913815"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="241913815"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">enabled: canClearCurrentLog</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">canClearCurrentLog</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1439</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: canClearAllLogs</string>
-						<reference key="source" ref="859424117"/>
-						<reference key="destination" ref="1021"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="859424117"/>
-							<reference key="NSDestination" ref="1021"/>
-							<string key="NSLabel">enabled: canClearAllLogs</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">canClearAllLogs</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">1441</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
-						<reference key="children" ref="1048"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="1021"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="1014"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1050"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">371</int>
-						<reference key="object" ref="972006081"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="439893737"/>
-							<reference ref="857264127"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">372</int>
-						<reference key="object" ref="439893737"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="252816051"/>
-						</array>
-						<reference key="parent" ref="972006081"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">455</int>
-						<reference key="object" ref="252816051"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="797179158"/>
-							<reference ref="161733749"/>
-						</array>
-						<reference key="parent" ref="439893737"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">456</int>
-						<reference key="object" ref="797179158"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1007791563"/>
-							<reference ref="136015987"/>
-						</array>
-						<reference key="parent" ref="252816051"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">457</int>
-						<reference key="object" ref="161733749"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="919832767"/>
-							<reference ref="1043255743"/>
-						</array>
-						<reference key="parent" ref="252816051"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">532</int>
-						<reference key="object" ref="923242454"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Filter Array Controller</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">493</int>
-						<reference key="object" ref="919832767"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="622971220"/>
-							<reference ref="984409547"/>
-							<reference ref="531691545"/>
-							<reference ref="692175765"/>
-						</array>
-						<reference key="parent" ref="161733749"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">488</int>
-						<reference key="object" ref="984409547"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="166932449"/>
-						</array>
-						<reference key="parent" ref="919832767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">489</int>
-						<reference key="object" ref="166932449"/>
-						<reference key="parent" ref="984409547"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">458</int>
-						<reference key="object" ref="1007791563"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="219283996"/>
-							<reference ref="983099424"/>
-						</array>
-						<reference key="parent" ref="797179158"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">510</int>
-						<reference key="object" ref="219283996"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="94898094"/>
-						</array>
-						<reference key="parent" ref="1007791563"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">511</int>
-						<reference key="object" ref="94898094"/>
-						<reference key="parent" ref="219283996"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">508</int>
-						<reference key="object" ref="983099424"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="303751880"/>
-						</array>
-						<reference key="parent" ref="1007791563"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">509</int>
-						<reference key="object" ref="303751880"/>
-						<reference key="parent" ref="983099424"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">586</int>
-						<reference key="object" ref="585219689"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="825133058"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Sheet (Filter Editor)</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">587</int>
-						<reference key="object" ref="825133058"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="473480621"/>
-							<reference ref="363399671"/>
-							<reference ref="763554720"/>
-							<reference ref="979771143"/>
-							<reference ref="45475269"/>
-						</array>
-						<reference key="parent" ref="585219689"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">588</int>
-						<reference key="object" ref="45475269"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1039326813"/>
-							<reference ref="283792662"/>
-							<reference ref="244222353"/>
-						</array>
-						<reference key="parent" ref="825133058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">589</int>
-						<reference key="object" ref="1039326813"/>
-						<reference key="parent" ref="45475269"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">590</int>
-						<reference key="object" ref="283792662"/>
-						<reference key="parent" ref="45475269"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">591</int>
-						<reference key="object" ref="244222353"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="996633552"/>
-							<reference ref="216723110"/>
-							<reference ref="338376168"/>
-							<reference ref="447301357"/>
-						</array>
-						<reference key="parent" ref="45475269"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">592</int>
-						<reference key="object" ref="996633552"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="13684657"/>
-							<reference ref="762256663"/>
-						</array>
-						<reference key="parent" ref="244222353"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">593</int>
-						<reference key="object" ref="216723110"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="729858560"/>
-							<reference ref="881984314"/>
-							<reference ref="1012339262"/>
-						</array>
-						<reference key="parent" ref="244222353"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">594</int>
-						<reference key="object" ref="729858560"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="950009332"/>
-						</array>
-						<reference key="parent" ref="216723110"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">595</int>
-						<reference key="object" ref="881984314"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="451760126"/>
-							<reference ref="251771017"/>
-						</array>
-						<reference key="parent" ref="216723110"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">599</int>
-						<reference key="object" ref="451760126"/>
-						<reference key="parent" ref="881984314"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">600</int>
-						<reference key="object" ref="251771017"/>
-						<reference key="parent" ref="881984314"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">604</int>
-						<reference key="object" ref="13684657"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="183674531"/>
-							<reference ref="20213531"/>
-							<reference ref="814094273"/>
-						</array>
-						<reference key="parent" ref="996633552"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">605</int>
-						<reference key="object" ref="762256663"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="931469284"/>
-						</array>
-						<reference key="parent" ref="996633552"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">606</int>
-						<reference key="object" ref="931469284"/>
-						<reference key="parent" ref="762256663"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">607</int>
-						<reference key="object" ref="183674531"/>
-						<reference key="parent" ref="13684657"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">608</int>
-						<reference key="object" ref="20213531"/>
-						<reference key="parent" ref="13684657"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">609</int>
-						<reference key="object" ref="473480621"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1010842736"/>
-						</array>
-						<reference key="parent" ref="825133058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">610</int>
-						<reference key="object" ref="1010842736"/>
-						<reference key="parent" ref="473480621"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">611</int>
-						<reference key="object" ref="363399671"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="566838678"/>
-						</array>
-						<reference key="parent" ref="825133058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">612</int>
-						<reference key="object" ref="566838678"/>
-						<reference key="parent" ref="363399671"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">613</int>
-						<reference key="object" ref="814094273"/>
-						<reference key="parent" ref="13684657"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">617</int>
-						<reference key="object" ref="950009332"/>
-						<reference key="parent" ref="729858560"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">688</int>
-						<reference key="object" ref="979771143"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="801978664"/>
-						</array>
-						<reference key="parent" ref="825133058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">689</int>
-						<reference key="object" ref="801978664"/>
-						<reference key="parent" ref="979771143"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">690</int>
-						<reference key="object" ref="763554720"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="450943096"/>
-						</array>
-						<reference key="parent" ref="825133058"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">691</int>
-						<reference key="object" ref="450943096"/>
-						<reference key="parent" ref="763554720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">819</int>
-						<reference key="object" ref="338376168"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="759074717"/>
-							<reference ref="298046528"/>
-						</array>
-						<reference key="parent" ref="244222353"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">820</int>
-						<reference key="object" ref="759074717"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="466785185"/>
-							<reference ref="728395743"/>
-							<reference ref="960006381"/>
-							<reference ref="846565375"/>
-							<reference ref="391995907"/>
-						</array>
-						<reference key="parent" ref="338376168"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">824</int>
-						<reference key="object" ref="298046528"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="158030715"/>
-							<reference ref="637184669"/>
-							<reference ref="1066770911"/>
-							<reference ref="516914548"/>
-							<reference ref="469243200"/>
-							<reference ref="210569817"/>
-							<reference ref="803680276"/>
-						</array>
-						<reference key="parent" ref="338376168"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">825</int>
-						<reference key="object" ref="158030715"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">826</int>
-						<reference key="object" ref="637184669"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">827</int>
-						<reference key="object" ref="1066770911"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">828</int>
-						<reference key="object" ref="516914548"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">829</int>
-						<reference key="object" ref="469243200"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">830</int>
-						<reference key="object" ref="210569817"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">831</int>
-						<reference key="object" ref="803680276"/>
-						<reference key="parent" ref="298046528"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">854</int>
-						<reference key="object" ref="1012339262"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="322944491"/>
-							<reference ref="668684702"/>
-							<reference ref="791387877"/>
-						</array>
-						<reference key="parent" ref="216723110"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">855</int>
-						<reference key="object" ref="322944491"/>
-						<reference key="parent" ref="1012339262"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">856</int>
-						<reference key="object" ref="668684702"/>
-						<reference key="parent" ref="1012339262"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">857</int>
-						<reference key="object" ref="791387877"/>
-						<reference key="parent" ref="1012339262"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">860</int>
-						<reference key="object" ref="447301357"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="355445859"/>
-							<reference ref="37608884"/>
-						</array>
-						<reference key="parent" ref="244222353"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">861</int>
-						<reference key="object" ref="355445859"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="340355613"/>
-							<reference ref="1006264860"/>
-						</array>
-						<reference key="parent" ref="447301357"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">865</int>
-						<reference key="object" ref="37608884"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="434776007"/>
-							<reference ref="749875840"/>
-							<reference ref="279679582"/>
-							<reference ref="394110264"/>
-							<reference ref="813620577"/>
-							<reference ref="138011791"/>
-						</array>
-						<reference key="parent" ref="447301357"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">869</int>
-						<reference key="object" ref="434776007"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">870</int>
-						<reference key="object" ref="749875840"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">875</int>
-						<reference key="object" ref="279679582"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">876</int>
-						<reference key="object" ref="394110264"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">877</int>
-						<reference key="object" ref="813620577"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">878</int>
-						<reference key="object" ref="138011791"/>
-						<reference key="parent" ref="37608884"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">894</int>
-						<reference key="object" ref="622971220"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="319025651"/>
-						</array>
-						<reference key="parent" ref="919832767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">895</int>
-						<reference key="object" ref="319025651"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="404327897"/>
-						</array>
-						<reference key="parent" ref="622971220"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">896</int>
-						<reference key="object" ref="404327897"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="267491286"/>
-							<reference ref="1063259389"/>
-							<reference ref="941498601"/>
-							<reference ref="599580337"/>
-							<reference ref="318690278"/>
-							<reference ref="779670545"/>
-							<reference ref="76018638"/>
-							<reference ref="443333885"/>
-							<reference ref="751047399"/>
-						</array>
-						<reference key="parent" ref="319025651"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">900</int>
-						<reference key="object" ref="267491286"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">908</int>
-						<reference key="object" ref="1063259389"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">909</int>
-						<reference key="object" ref="941498601"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">910</int>
-						<reference key="object" ref="599580337"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">911</int>
-						<reference key="object" ref="76018638"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">914</int>
-						<reference key="object" ref="318690278"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">915</int>
-						<reference key="object" ref="779670545"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">477</int>
-						<reference key="object" ref="1043255743"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="122654608"/>
-							<reference ref="426073056"/>
-							<reference ref="522308002"/>
-						</array>
-						<reference key="parent" ref="161733749"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">478</int>
-						<reference key="object" ref="122654608"/>
-						<reference key="parent" ref="1043255743"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">479</int>
-						<reference key="object" ref="426073056"/>
-						<reference key="parent" ref="1043255743"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">480</int>
-						<reference key="object" ref="522308002"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="759397915"/>
-						</array>
-						<reference key="parent" ref="1043255743"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">482</int>
-						<reference key="object" ref="759397915"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="738305309"/>
-						</array>
-						<reference key="parent" ref="522308002"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">485</int>
-						<reference key="object" ref="738305309"/>
-						<reference key="parent" ref="759397915"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">936</int>
-						<reference key="object" ref="443333885"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">938</int>
-						<reference key="object" ref="751047399"/>
-						<reference key="parent" ref="404327897"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">943</int>
-						<reference key="object" ref="136015987"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="196019381"/>
-							<reference ref="624715448"/>
-						</array>
-						<reference key="parent" ref="797179158"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">944</int>
-						<reference key="object" ref="196019381"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="150906237"/>
-							<reference ref="150030323"/>
-						</array>
-						<reference key="parent" ref="136015987"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">946</int>
-						<reference key="object" ref="150906237"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="179564853"/>
-							<reference ref="206027241"/>
-						</array>
-						<reference key="parent" ref="196019381"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">947</int>
-						<reference key="object" ref="179564853"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="332977932"/>
-						</array>
-						<reference key="parent" ref="150906237"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">948</int>
-						<reference key="object" ref="206027241"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="253161491"/>
-						</array>
-						<reference key="parent" ref="150906237"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">949</int>
-						<reference key="object" ref="253161491"/>
-						<reference key="parent" ref="206027241"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">950</int>
-						<reference key="object" ref="332977932"/>
-						<reference key="parent" ref="179564853"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">954</int>
-						<reference key="object" ref="150030323"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="152728781"/>
-							<reference ref="441275434"/>
-							<reference ref="802786105"/>
-							<reference ref="563313961"/>
-						</array>
-						<reference key="parent" ref="196019381"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">955</int>
-						<reference key="object" ref="152728781"/>
-						<reference key="parent" ref="150030323"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">956</int>
-						<reference key="object" ref="441275434"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="612119745"/>
-						</array>
-						<reference key="parent" ref="150030323"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">957</int>
-						<reference key="object" ref="802786105"/>
-						<reference key="parent" ref="150030323"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">958</int>
-						<reference key="object" ref="563313961"/>
-						<reference key="parent" ref="150030323"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">959</int>
-						<reference key="object" ref="612119745"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="628322093"/>
-						</array>
-						<reference key="parent" ref="441275434"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">960</int>
-						<reference key="object" ref="628322093"/>
-						<reference key="parent" ref="612119745"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">963</int>
-						<reference key="object" ref="78795738"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Filter Sets Array Controller</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1090</int>
-						<reference key="object" ref="531691545"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="672475580"/>
-						</array>
-						<reference key="parent" ref="919832767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1091</int>
-						<reference key="object" ref="672475580"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="14458767"/>
-						</array>
-						<reference key="parent" ref="531691545"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1092</int>
-						<reference key="object" ref="14458767"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="895409037"/>
-							<reference ref="634578148"/>
-							<reference ref="1071402364"/>
-							<reference ref="796904695"/>
-							<reference ref="598597192"/>
-							<reference ref="537658706"/>
-							<reference ref="241913815"/>
-							<reference ref="859424117"/>
-						</array>
-						<reference key="parent" ref="672475580"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1095</int>
-						<reference key="object" ref="895409037"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1094</int>
-						<reference key="object" ref="634578148"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1093</int>
-						<reference key="object" ref="1071402364"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1104</int>
-						<reference key="object" ref="930602132"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="279634916"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Sheet (Add Mark)</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1105</int>
-						<reference key="object" ref="279634916"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="183329842"/>
-							<reference ref="932005013"/>
-							<reference ref="807984468"/>
-							<reference ref="726699141"/>
-						</array>
-						<reference key="parent" ref="930602132"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1107</int>
-						<reference key="object" ref="183329842"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="562290842"/>
-						</array>
-						<reference key="parent" ref="279634916"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1108</int>
-						<reference key="object" ref="932005013"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="226479939"/>
-						</array>
-						<reference key="parent" ref="279634916"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1109</int>
-						<reference key="object" ref="726699141"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="141491742"/>
-						</array>
-						<reference key="parent" ref="279634916"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1110</int>
-						<reference key="object" ref="807984468"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="538657820"/>
-						</array>
-						<reference key="parent" ref="279634916"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1111</int>
-						<reference key="object" ref="538657820"/>
-						<reference key="parent" ref="807984468"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1112</int>
-						<reference key="object" ref="141491742"/>
-						<reference key="parent" ref="726699141"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1113</int>
-						<reference key="object" ref="226479939"/>
-						<reference key="parent" ref="932005013"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1114</int>
-						<reference key="object" ref="562290842"/>
-						<reference key="parent" ref="183329842"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1206</int>
-						<reference key="object" ref="692175765"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="407396953"/>
-						</array>
-						<reference key="parent" ref="919832767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1207</int>
-						<reference key="object" ref="407396953"/>
-						<reference key="parent" ref="692175765"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1229</int>
-						<reference key="object" ref="466785185"/>
-						<reference key="parent" ref="759074717"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1230</int>
-						<reference key="object" ref="728395743"/>
-						<reference key="parent" ref="759074717"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1231</int>
-						<reference key="object" ref="960006381"/>
-						<reference key="parent" ref="759074717"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1232</int>
-						<reference key="object" ref="846565375"/>
-						<reference key="parent" ref="759074717"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1233</int>
-						<reference key="object" ref="391995907"/>
-						<reference key="parent" ref="759074717"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1234</int>
-						<reference key="object" ref="340355613"/>
-						<reference key="parent" ref="355445859"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1235</int>
-						<reference key="object" ref="1006264860"/>
-						<reference key="parent" ref="355445859"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1245</int>
-						<reference key="object" ref="796904695"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1270</int>
-						<reference key="object" ref="857264127"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="855220083"/>
-							<reference ref="654955765"/>
-							<reference ref="727069989"/>
-							<reference ref="608132524"/>
-							<reference ref="1009168716"/>
-							<reference ref="999087205"/>
-							<reference ref="958014623"/>
-							<reference ref="1072918009"/>
-							<reference ref="50987833"/>
-						</array>
-						<reference key="parent" ref="972006081"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1273</int>
-						<reference key="object" ref="855220083"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1275</int>
-						<reference key="object" ref="654955765"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1276</int>
-						<reference key="object" ref="727069989"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1300</int>
-						<reference key="object" ref="608132524"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="26638440"/>
-						</array>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1298</int>
-						<reference key="object" ref="26638440"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="490457310"/>
-						</array>
-						<reference key="parent" ref="608132524"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1299</int>
-						<reference key="object" ref="490457310"/>
-						<reference key="parent" ref="26638440"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1309</int>
-						<reference key="object" ref="1009168716"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1324</int>
-						<reference key="object" ref="999087205"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1325</int>
-						<reference key="object" ref="958014623"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1330</int>
-						<reference key="object" ref="1072918009"/>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1416</int>
-						<reference key="object" ref="50987833"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="336153473"/>
-						</array>
-						<reference key="parent" ref="857264127"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1410</int>
-						<reference key="object" ref="336153473"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="938642101"/>
-						</array>
-						<reference key="parent" ref="50987833"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1411</int>
-						<reference key="object" ref="938642101"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="714326863"/>
-						</array>
-						<reference key="parent" ref="336153473"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1412</int>
-						<reference key="object" ref="714326863"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="349154456"/>
-							<reference ref="741388438"/>
-							<reference ref="832166084"/>
-						</array>
-						<reference key="parent" ref="938642101"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1415</int>
-						<reference key="object" ref="349154456"/>
-						<reference key="parent" ref="714326863"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1414</int>
-						<reference key="object" ref="741388438"/>
-						<reference key="parent" ref="714326863"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1413</int>
-						<reference key="object" ref="832166084"/>
-						<reference key="parent" ref="714326863"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1426</int>
-						<reference key="object" ref="324114734"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1432</int>
-						<reference key="object" ref="598597192"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1433</int>
-						<reference key="object" ref="537658706"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1434</int>
-						<reference key="object" ref="241913815"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1435</int>
-						<reference key="object" ref="859424117"/>
-						<reference key="parent" ref="14458767"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">945</int>
-						<reference key="object" ref="624715448"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="624289750"/>
-						</array>
-						<reference key="parent" ref="136015987"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">468</int>
-						<reference key="object" ref="624289750"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="940204013"/>
-							<reference ref="682997029"/>
-							<reference ref="150938961"/>
-							<reference ref="697792232"/>
-						</array>
-						<reference key="parent" ref="624715448"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">472</int>
-						<reference key="object" ref="697792232"/>
-						<reference key="parent" ref="624289750"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">471</int>
-						<reference key="object" ref="150938961"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="34494719"/>
-						</array>
-						<reference key="parent" ref="624289750"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">473</int>
-						<reference key="object" ref="34494719"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="871845118"/>
-						</array>
-						<reference key="parent" ref="150938961"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">476</int>
-						<reference key="object" ref="871845118"/>
-						<reference key="parent" ref="34494719"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">470</int>
-						<reference key="object" ref="682997029"/>
-						<reference key="parent" ref="624289750"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">469</int>
-						<reference key="object" ref="940204013"/>
-						<reference key="parent" ref="624289750"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1090.CustomClassName">BWAnchoredPopUpButton</string>
-				<string key="1090.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1091.CustomClassName">BWAnchoredPopUpButtonCell</string>
-				<string key="1091.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1092.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1093.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1094.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1095.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1104.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1104.IBWindowTemplateEditedContentRect">{{25, 380}, {480, 111}}</string>
-				<boolean value="NO" key="1104.NSWindowTemplate.visibleAtLaunch"/>
-				<string key="1105.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1107.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1108.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1109.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1110.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1111.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1112.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1113.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1114.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1206.CustomClassName">BWAnchoredButton</string>
-				<object class="NSMutableDictionary" key="1206.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="692175765"/>
-						<string key="toolTip">Show / Hide file, line and function names</string>
-					</object>
-				</object>
-				<string key="1206.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1207.CustomClassName">BWAnchoredButtonCell</string>
-				<string key="1207.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1229.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1230.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1232.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1233.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1234.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1235.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1245.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1270.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1270.designableToolbarIdentifier">LoggerWindowToolbar</string>
-				<string key="1273.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1275.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1276.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1298.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1299.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1300.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1309.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="NO" key="1309.toolbarItem.selectable"/>
-				<string key="1324.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1325.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1330.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1410.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1411.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1412.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1413.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1414.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1415.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1416.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1426.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1432.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1433.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1434.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="1435.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="371.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="371.IBWindowTemplateEditedContentRect">{{139, 145}, {885, 666}}</string>
-				<integer value="1" key="371.NSWindowTemplate.visibleAtLaunch"/>
-				<string key="372.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="455.CustomClassName">LoggerSplitView</string>
-				<object class="NSMutableDictionary" key="455.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="252816051"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">colorIsEnabled</string>
-								<boolean value="YES" key="value"/>
-							</object>
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">dividerCanCollapse</string>
-								<boolean value="NO" key="value"/>
-							</object>
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">collapsiblePopupSelection</string>
-								<integer value="1" key="value"/>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="455.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="456.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="457.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="458.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="1007791563"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">selectedIndex</string>
-								<integer value="0" key="value"/>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="458.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="468.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="469.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="470.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="471.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="150938961"/>
-						<string key="toolTip">Select one or more items to filter log messages</string>
-					</object>
-				</object>
-				<string key="471.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="472.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="473.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="476.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="477.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="478.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="479.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="480.CustomClassName">LoggerTableView</string>
-				<string key="480.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="482.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="485.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="488.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="984409547"/>
-						<string key="toolTip">Number of messages displayed</string>
-					</object>
-				</object>
-				<string key="488.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="489.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="493.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="919832767"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">selectedIndex</string>
-								<integer value="1" key="value"/>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="493.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="508.CustomClassName">BWAnchoredButton</string>
-				<object class="NSMutableDictionary" key="508.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="983099424"/>
-						<string key="toolTip">Add a new filter</string>
-					</object>
-				</object>
-				<string key="508.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="509.CustomClassName">BWAnchoredButtonCell</string>
-				<string key="509.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="510.CustomClassName">BWAnchoredButton</string>
-				<object class="NSMutableDictionary" key="510.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="219283996"/>
-						<string key="toolTip">Delete selected filter</string>
-					</object>
-				</object>
-				<string key="510.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="511.CustomClassName">BWAnchoredButtonCell</string>
-				<string key="511.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="532.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="586.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="586.IBWindowTemplateEditedContentRect">{{196, 223}, {480, 270}}</string>
-				<boolean value="NO" key="586.NSWindowTemplate.visibleAtLaunch"/>
-				<string key="587.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="588.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="589.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="590.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="591.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="592.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="593.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="594.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="595.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="599.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="600.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="604.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="605.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="606.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="607.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="608.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="609.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="610.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="611.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="612.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="613.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="617.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="688.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="689.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="690.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="691.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="819.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="820.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="824.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="825.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="826.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="827.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="828.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="829.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="830.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="831.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="854.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="855.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="856.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="857.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="860.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="861.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="865.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="869.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="870.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="875.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="876.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="877.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="878.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="894.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="622971220"/>
-						<string key="toolTip">Refine filter to display only messages with the selected level and/or tag</string>
-					</object>
-				</object>
-				<string key="894.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<real value="0.0" key="894.IBViewIntegration.shadowBlurRadius"/>
-				<object class="NSColor" key="894.IBViewIntegration.shadowColor">
-					<int key="NSColorSpace">1</int>
-					<bytes key="NSRGB">MC41MTYzMDQzNDc4IDAuNTE2MzA0MzQ3OCAwLjUxNjMwNDM0NzgAA</bytes>
-				</object>
-				<real value="0.0" key="894.IBViewIntegration.shadowOffsetHeight"/>
-				<real value="0.0" key="894.IBViewIntegration.shadowOffsetWidth"/>
-				<string key="895.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="896.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="900.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="908.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="909.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="910.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="911.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="914.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="915.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="936.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="938.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="943.CustomClassName">BWSplitView</string>
-				<object class="NSMutableDictionary" key="943.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="136015987"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">colorIsEnabled</string>
-								<boolean value="NO" key="value"/>
-							</object>
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">dividerCanCollapse</string>
-								<boolean value="NO" key="value"/>
-							</object>
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">collapsiblePopupSelection</string>
-								<integer value="2" key="value"/>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="943.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="944.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="945.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="946.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="150906237"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.number</string>
-								<string key="keyPath">selectedIndex</string>
-								<integer value="2" key="value"/>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="946.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="947.CustomClassName">BWAnchoredButton</string>
-				<object class="NSMutableDictionary" key="947.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="179564853"/>
-						<string key="toolTip">Add a new filter set</string>
-					</object>
-				</object>
-				<string key="947.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="948.CustomClassName">BWAnchoredButton</string>
-				<object class="NSMutableDictionary" key="948.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="206027241"/>
-						<string key="toolTip">Delete selected filter set</string>
-					</object>
-				</object>
-				<string key="948.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="949.CustomClassName">BWAnchoredButtonCell</string>
-				<string key="949.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="950.CustomClassName">BWAnchoredButtonCell</string>
-				<string key="950.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="954.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="955.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="956.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="957.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="958.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="959.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="960.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="963.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">1455</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">BWAnchoredButton</string>
-					<string key="superclassName">NSButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWAnchoredButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">BWAnchoredButtonBar</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWAnchoredButtonBar.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">BWAnchoredButtonCell</string>
-					<string key="superclassName">NSButtonCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWAnchoredButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">BWAnchoredPopUpButton</string>
-					<string key="superclassName">NSPopUpButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWAnchoredPopUpButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">BWAnchoredPopUpButtonCell</string>
-					<string key="superclassName">NSPopUpButtonCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWAnchoredPopUpButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">BWSplitView</string>
-					<string key="superclassName">NSSplitView</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">toggleCollapse:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">toggleCollapse:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BWSplitView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">LoggerAppDelegate</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">showPreferences:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">showPreferences:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">showPreferences:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/LoggerAppDelegate.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">LoggerSplitView</string>
-					<string key="superclassName">BWSplitView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/LoggerSplitView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">LoggerTableView</string>
-					<string key="superclassName">NSTableView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/LoggerTableView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">LoggerWindowController</string>
-					<string key="superclassName">NSWindowController</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="addFilter:">id</string>
-						<string key="addFilterSet:">id</string>
-						<string key="addMark:">id</string>
-						<string key="addMarkWithTitle:">id</string>
-						<string key="cancelAddMark:">id</string>
-						<string key="cancelFilterEdition:">id</string>
-						<string key="clearAllLogs:">id</string>
-						<string key="clearCurrentLog:">id</string>
-						<string key="collapseTaskbar:">id</string>
-						<string key="createNewFilterFromQuickFilter:">id</string>
-						<string key="deleteMark:">id</string>
-						<string key="deleteSelectedFilterSet:">id</string>
-						<string key="deleteSelectedFilters:">id</string>
-						<string key="insertMarkWithTitle:">id</string>
-						<string key="openDetailsWindow:">id</string>
-						<string key="resetQuickFilter:">id</string>
-						<string key="selectQuickFilterLevel:">id</string>
-						<string key="selectQuickFilterTag:">id</string>
-						<string key="startEditingFilter:">id</string>
-						<string key="validateAddMark:">id</string>
-						<string key="validateFilterEdition:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="addFilter:">
-							<string key="name">addFilter:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addFilterSet:">
-							<string key="name">addFilterSet:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addMark:">
-							<string key="name">addMark:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="addMarkWithTitle:">
-							<string key="name">addMarkWithTitle:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="cancelAddMark:">
-							<string key="name">cancelAddMark:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="cancelFilterEdition:">
-							<string key="name">cancelFilterEdition:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="clearAllLogs:">
-							<string key="name">clearAllLogs:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="clearCurrentLog:">
-							<string key="name">clearCurrentLog:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="collapseTaskbar:">
-							<string key="name">collapseTaskbar:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="createNewFilterFromQuickFilter:">
-							<string key="name">createNewFilterFromQuickFilter:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="deleteMark:">
-							<string key="name">deleteMark:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="deleteSelectedFilterSet:">
-							<string key="name">deleteSelectedFilterSet:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="deleteSelectedFilters:">
-							<string key="name">deleteSelectedFilters:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="insertMarkWithTitle:">
-							<string key="name">insertMarkWithTitle:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="openDetailsWindow:">
-							<string key="name">openDetailsWindow:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="resetQuickFilter:">
-							<string key="name">resetQuickFilter:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectQuickFilterLevel:">
-							<string key="name">selectQuickFilterLevel:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="selectQuickFilterTag:">
-							<string key="name">selectQuickFilterTag:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="startEditingFilter:">
-							<string key="name">startEditingFilter:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="validateAddMark:">
-							<string key="name">validateAddMark:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="validateFilterEdition:">
-							<string key="name">validateFilterEdition:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="buttonBar">BWAnchoredButtonBar</string>
-						<string key="filterEditor">NSPredicateEditor</string>
-						<string key="filterEditorWindow">NSWindow</string>
-						<string key="filterListController">NSArrayController</string>
-						<string key="filterName">NSTextField</string>
-						<string key="filterSetsListController">NSArrayController</string>
-						<string key="filterSetsTable">NSTableView</string>
-						<string key="filterTable">NSTableView</string>
-						<string key="logTable">LoggerTableView</string>
-						<string key="markTitleField">NSTextField</string>
-						<string key="markTitleWindow">NSWindow</string>
-						<string key="quickFilter">NSPopUpButton</string>
-						<string key="quickFilterTextField">NSSearchField</string>
-						<string key="showFunctionNamesButton">NSButton</string>
-						<string key="splitView">LoggerSplitView</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="buttonBar">
-							<string key="name">buttonBar</string>
-							<string key="candidateClassName">BWAnchoredButtonBar</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterEditor">
-							<string key="name">filterEditor</string>
-							<string key="candidateClassName">NSPredicateEditor</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterEditorWindow">
-							<string key="name">filterEditorWindow</string>
-							<string key="candidateClassName">NSWindow</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterListController">
-							<string key="name">filterListController</string>
-							<string key="candidateClassName">NSArrayController</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterName">
-							<string key="name">filterName</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterSetsListController">
-							<string key="name">filterSetsListController</string>
-							<string key="candidateClassName">NSArrayController</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterSetsTable">
-							<string key="name">filterSetsTable</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterTable">
-							<string key="name">filterTable</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="logTable">
-							<string key="name">logTable</string>
-							<string key="candidateClassName">LoggerTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="markTitleField">
-							<string key="name">markTitleField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="markTitleWindow">
-							<string key="name">markTitleWindow</string>
-							<string key="candidateClassName">NSWindow</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="quickFilter">
-							<string key="name">quickFilter</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="quickFilterTextField">
-							<string key="name">quickFilterTextField</string>
-							<string key="candidateClassName">NSSearchField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showFunctionNamesButton">
-							<string key="name">showFunctionNamesButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="splitView">
-							<string key="name">splitView</string>
-							<string key="candidateClassName">LoggerSplitView</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/LoggerWindowController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<integer value="1060" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="3200" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="Export">{32, 32}</string>
-			<string key="Load">{48, 48}</string>
-			<string key="NSActionTemplate">{15, 15}</string>
-			<string key="NSAddTemplate">{8, 8}</string>
-			<string key="NSAdvanced">{32, 32}</string>
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
-			<string key="NSRemoveTemplate">{8, 8}</string>
-			<string key="Save">{48, 48}</string>
-		</dictionary>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment version="1070" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="LoggerWindowController">
+            <connections>
+                <outlet property="buttonBar" destination="458" id="934"/>
+                <outlet property="filterEditor" destination="591" id="815"/>
+                <outlet property="filterEditorWindow" destination="586" id="814"/>
+                <outlet property="filterListController" destination="532" id="702"/>
+                <outlet property="filterName" destination="688" id="818"/>
+                <outlet property="filterSetsListController" destination="963" id="973"/>
+                <outlet property="filterSetsTable" destination="956" id="972"/>
+                <outlet property="filterTable" destination="471" id="893"/>
+                <outlet property="logTable" destination="480" id="535"/>
+                <outlet property="markTitleField" destination="1107" id="1161"/>
+                <outlet property="markTitleWindow" destination="1104" id="1160"/>
+                <outlet property="quickFilter" destination="894" id="912"/>
+                <outlet property="quickFilterTextField" destination="1298" id="1301"/>
+                <outlet property="showFunctionNamesButton" destination="1206" id="1221"/>
+                <outlet property="splitView" destination="455" id="1444"/>
+                <outlet property="window" destination="371" id="813"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="NSLogger" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" id="371">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="154" y="384" width="885" height="666"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <value key="minSize" type="size" width="700" height="500"/>
+            <view key="contentView" id="372">
+                <rect key="frame" x="0.0" y="0.0" width="885" height="666"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <splitView focusRingType="none" autosaveName="MainSplit" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="455" customClass="LoggerSplitView">
+                        <rect key="frame" x="0.0" y="0.0" width="885" height="666"/>
+                        <subviews>
+                            <customView id="456">
+                                <rect key="frame" x="0.0" y="0.0" width="100" height="666"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <splitView autosaveName="SidebarSplit" translatesAutoresizingMaskIntoConstraints="NO" id="943" customClass="BWSplitView">
+                                        <rect key="frame" x="0.0" y="24" width="100" height="642"/>
+                                        <subviews>
+                                            <customView id="944">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="280"/>
+                                                <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
+                                                <subviews>
+                                                    <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="946" customClass="BWAnchoredButtonBar">
+                                                        <rect key="frame" x="0.0" y="0.0" width="100" height="24"/>
+                                                        <subviews>
+                                                            <button toolTip="Delete selected filter set" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="948" customClass="BWAnchoredButton">
+                                                                <rect key="frame" x="34" y="2" width="32" height="19"/>
+                                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="949" customClass="BWAnchoredButtonCell">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="deleteSelectedFilterSet:" target="-2" id="975"/>
+                                                                    <binding destination="963" name="enabled" keyPath="selectedObjects" id="976">
+                                                                        <dictionary key="options">
+                                                                            <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                                            <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                                            <integer key="NSNullPlaceholder" value="0"/>
+                                                                            <string key="NSValueTransformerName">CanDeleteFilterSelection</string>
+                                                                        </dictionary>
+                                                                    </binding>
+                                                                </connections>
+                                                            </button>
+                                                            <button toolTip="Add a new filter set" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="947" customClass="BWAnchoredButton">
+                                                                <rect key="frame" x="2" y="2" width="32" height="19"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="32" id="yDf-os-fWi"/>
+                                                                </constraints>
+                                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSAddTemplate" imagePosition="only" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="950" customClass="BWAnchoredButtonCell">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="addFilterSet:" target="-2" id="974"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="948" firstAttribute="leading" secondItem="947" secondAttribute="trailing" id="414-PJ-FIO"/>
+                                                            <constraint firstItem="948" firstAttribute="width" secondItem="947" secondAttribute="width" id="6AM-QN-3ZO"/>
+                                                            <constraint firstItem="948" firstAttribute="centerY" secondItem="946" secondAttribute="centerY" id="HqQ-Wg-QfR"/>
+                                                            <constraint firstAttribute="height" constant="24" id="NA2-jd-gTR"/>
+                                                            <constraint firstItem="947" firstAttribute="centerY" secondItem="946" secondAttribute="centerY" id="QeY-cj-fHc"/>
+                                                            <constraint firstItem="947" firstAttribute="leading" secondItem="946" secondAttribute="leading" constant="2" id="fP1-7U-RA7"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="selectedIndex">
+                                                                <integer key="value" value="2"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </customView>
+                                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="954">
+                                                        <rect key="frame" x="0.0" y="24" width="100" height="256"/>
+                                                        <clipView key="contentView" drawsBackground="NO" id="NFH-4N-Ty8">
+                                                            <rect key="frame" x="0.0" y="0.0" width="100" height="256"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="20" headerView="955" id="956">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="233"/>
+                                                                    <autoresizingMask key="autoresizingMask"/>
+                                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                                    <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                                    <tableColumns>
+                                                                        <tableColumn identifier="filtersets" width="97" minWidth="40" maxWidth="1000" id="959">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Application Sets">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Text Cell" id="960">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                            <connections>
+                                                                                <binding destination="963" name="value" keyPath="arrangedObjects.title" id="980">
+                                                                                    <dictionary key="options">
+                                                                                        <bool key="NSConditionallySetsEditable" value="YES"/>
+                                                                                        <bool key="NSCreatesSortDescriptor" value="NO"/>
+                                                                                    </dictionary>
+                                                                                </binding>
+                                                                            </connections>
+                                                                        </tableColumn>
+                                                                    </tableColumns>
+                                                                    <connections>
+                                                                        <outlet property="dataSource" destination="-2" id="997"/>
+                                                                        <outlet property="delegate" destination="-2" id="971"/>
+                                                                    </connections>
+                                                                </tableView>
+                                                            </subviews>
+                                                            <nil key="backgroundColor"/>
+                                                        </clipView>
+                                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="957">
+                                                            <rect key="frame" x="-100" y="-100" width="200" height="15"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="958">
+                                                            <rect key="frame" x="-16" y="23" width="16" height="0.0"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <tableHeaderView key="headerView" focusRingType="exterior" id="955">
+                                                            <rect key="frame" x="0.0" y="0.0" width="100" height="23"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </tableHeaderView>
+                                                    </scrollView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="954" firstAttribute="top" secondItem="944" secondAttribute="top" id="9Vn-Xn-oTs"/>
+                                                    <constraint firstItem="954" firstAttribute="leading" secondItem="944" secondAttribute="leading" id="GLV-NT-eDZ"/>
+                                                    <constraint firstAttribute="bottom" secondItem="946" secondAttribute="bottom" id="Qnw-VA-cl8"/>
+                                                    <constraint firstAttribute="trailing" secondItem="954" secondAttribute="trailing" id="SnO-Ri-VkT"/>
+                                                    <constraint firstAttribute="trailing" secondItem="946" secondAttribute="trailing" id="Xrz-SR-ZCh"/>
+                                                    <constraint firstItem="946" firstAttribute="top" secondItem="954" secondAttribute="bottom" id="fwz-C5-Eim"/>
+                                                    <constraint firstItem="946" firstAttribute="leading" secondItem="944" secondAttribute="leading" id="z7Z-r9-eDH"/>
+                                                </constraints>
+                                            </customView>
+                                            <customView id="945">
+                                                <rect key="frame" x="0.0" y="289" width="100" height="353"/>
+                                                <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
+                                                <subviews>
+                                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="468">
+                                                        <rect key="frame" x="0.0" y="0.0" width="100" height="353"/>
+                                                        <clipView key="contentView" drawsBackground="NO" id="2xl-Wm-Xku">
+                                                            <rect key="frame" x="0.0" y="0.0" width="100" height="353"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <tableView toolTip="Select one or more items to filter log messages" focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="20" headerView="472" id="471">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="330"/>
+                                                                    <autoresizingMask key="autoresizingMask"/>
+                                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                                    <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                                    <tableColumns>
+                                                                        <tableColumn identifier="filters" editable="NO" width="97" minWidth="40" maxWidth="1000" id="473">
+                                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Filters">
+                                                                                <font key="font" metaFont="smallSystem"/>
+                                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                                            </tableHeaderCell>
+                                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="476">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                            <connections>
+                                                                                <binding destination="532" name="value" keyPath="arrangedObjects.title" id="981">
+                                                                                    <dictionary key="options">
+                                                                                        <bool key="NSConditionallySetsEditable" value="YES"/>
+                                                                                        <bool key="NSCreatesSortDescriptor" value="NO"/>
+                                                                                    </dictionary>
+                                                                                </binding>
+                                                                                <binding destination="963" name="headerTitle" keyPath="selection.title" id="1191">
+                                                                                    <dictionary key="options">
+                                                                                        <string key="NSNoSelectionPlaceholder">No Selection</string>
+                                                                                        <string key="NSNullPlaceholder">No Selection</string>
+                                                                                        <string key="NSValueTransformerName">FilterColumnHeader</string>
+                                                                                    </dictionary>
+                                                                                </binding>
+                                                                            </connections>
+                                                                        </tableColumn>
+                                                                    </tableColumns>
+                                                                    <connections>
+                                                                        <outlet property="dataSource" destination="-2" id="998"/>
+                                                                        <outlet property="delegate" destination="-2" id="935"/>
+                                                                    </connections>
+                                                                </tableView>
+                                                            </subviews>
+                                                            <nil key="backgroundColor"/>
+                                                        </clipView>
+                                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.38532110091743121" horizontal="YES" id="470">
+                                                            <rect key="frame" x="-100" y="-100" width="200" height="15"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="469">
+                                                            <rect key="frame" x="-16" y="23" width="16" height="0.0"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </scroller>
+                                                        <tableHeaderView key="headerView" focusRingType="exterior" id="472">
+                                                            <rect key="frame" x="0.0" y="0.0" width="100" height="23"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </tableHeaderView>
+                                                    </scrollView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="468" secondAttribute="bottom" id="CY7-tU-dEa"/>
+                                                    <constraint firstItem="468" firstAttribute="leading" secondItem="945" secondAttribute="leading" id="OE0-xU-0Sb"/>
+                                                    <constraint firstItem="468" firstAttribute="top" secondItem="945" secondAttribute="top" id="fk5-od-st8"/>
+                                                    <constraint firstAttribute="trailing" secondItem="468" secondAttribute="trailing" id="mp4-W5-eez"/>
+                                                </constraints>
+                                            </customView>
+                                        </subviews>
+                                        <holdingPriorities>
+                                            <real value="250"/>
+                                            <real value="250"/>
+                                        </holdingPriorities>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="colorIsEnabled">
+                                                <bool key="value" value="NO"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="dividerCanCollapse">
+                                                <bool key="value" value="NO"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="collapsiblePopupSelection">
+                                                <integer key="value" value="2"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </splitView>
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="458" customClass="BWAnchoredButtonBar">
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="24"/>
+                                        <subviews>
+                                            <button toolTip="Delete selected filter" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="510" customClass="BWAnchoredButton">
+                                                <rect key="frame" x="38" y="2" width="32" height="19"/>
+                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" controlSize="small" borderStyle="border" inset="2" id="511" customClass="BWAnchoredButtonCell">
+                                                    <behavior key="behavior" lightByContents="YES"/>
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="deleteSelectedFilters:" target="-2" id="926"/>
+                                                    <binding destination="532" name="enabled" keyPath="selectedObjects" id="985">
+                                                        <dictionary key="options">
+                                                            <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                            <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                            <integer key="NSNullPlaceholder" value="0"/>
+                                                            <string key="NSValueTransformerName">CanDeleteFilterSelection</string>
+                                                        </dictionary>
+                                                    </binding>
+                                                </connections>
+                                            </button>
+                                            <button toolTip="Add a new filter" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="508" customClass="BWAnchoredButton">
+                                                <rect key="frame" x="4" y="2" width="32" height="19"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="32" id="SDs-U4-spm"/>
+                                                </constraints>
+                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSAddTemplate" imagePosition="overlaps" alignment="center" controlSize="small" borderStyle="border" inset="2" id="509" customClass="BWAnchoredButtonCell">
+                                                    <behavior key="behavior" lightByContents="YES"/>
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="addFilter:" target="-2" id="701"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="510" firstAttribute="leading" secondItem="508" secondAttribute="trailing" constant="2" id="RVc-Kx-gmb"/>
+                                            <constraint firstItem="508" firstAttribute="centerY" secondItem="458" secondAttribute="centerY" id="Tor-3v-0ta"/>
+                                            <constraint firstItem="510" firstAttribute="width" secondItem="508" secondAttribute="width" id="fXY-3W-SP2"/>
+                                            <constraint firstItem="510" firstAttribute="centerY" secondItem="458" secondAttribute="centerY" id="pNw-Yk-0NU"/>
+                                            <constraint firstAttribute="height" constant="24" id="xxq-oe-sbW"/>
+                                            <constraint firstItem="508" firstAttribute="leading" secondItem="458" secondAttribute="leading" constant="4" id="zn7-wd-BS6"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="selectedIndex">
+                                                <integer key="value" value="0"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </customView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="458" secondAttribute="trailing" id="105-77-Jfq"/>
+                                    <constraint firstItem="458" firstAttribute="top" secondItem="943" secondAttribute="bottom" id="CS5-lR-zAQ"/>
+                                    <constraint firstItem="943" firstAttribute="top" secondItem="456" secondAttribute="top" id="Ddu-10-xM0"/>
+                                    <constraint firstAttribute="trailing" secondItem="943" secondAttribute="trailing" id="NHJ-4S-3vj"/>
+                                    <constraint firstItem="943" firstAttribute="leading" secondItem="456" secondAttribute="leading" id="b4A-xu-2jk"/>
+                                    <constraint firstItem="458" firstAttribute="leading" secondItem="456" secondAttribute="leading" id="tho-Zq-eAj"/>
+                                    <constraint firstAttribute="bottom" secondItem="458" secondAttribute="bottom" id="ylq-J4-kJi"/>
+                                </constraints>
+                            </customView>
+                            <customView id="457">
+                                <rect key="frame" x="101" y="0.0" width="784" height="666"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <scrollView borderType="none" horizontalLineScroll="46" horizontalPageScroll="10" verticalLineScroll="46" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="477">
+                                        <rect key="frame" x="0.0" y="22" width="784" height="644"/>
+                                        <clipView key="contentView" copiesOnScroll="NO" id="PLm-aZ-COI">
+                                            <rect key="frame" x="0.0" y="0.0" width="784" height="644"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" columnReordering="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="44" id="480" customClass="LoggerTableView">
+                                                    <rect key="frame" x="0.0" y="0.0" width="784" height="644"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" white="0.97000002860000001" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="gridColor" red="0.93923854829999998" green="0.93923854829999998" blue="0.93923854829999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="message" width="781" minWidth="200" maxWidth="10000" id="482">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="485">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                    <connections>
+                                                        <outlet property="dataSource" destination="-2" id="941"/>
+                                                        <outlet property="delegate" destination="-2" id="942"/>
+                                                    </connections>
+                                                </tableView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.97000002860000001" alpha="1" colorSpace="calibratedWhite"/>
+                                        </clipView>
+                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.59969325153374209" horizontal="YES" id="479">
+                                            <rect key="frame" x="-100" y="-100" width="650" height="15"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="0.97981366459627328" horizontal="NO" id="478">
+                                            <rect key="frame" x="768" y="0.0" width="16" height="644"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                    <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="493" customClass="BWAnchoredButtonBar">
+                                        <rect key="frame" x="0.0" y="0.0" width="784" height="24"/>
+                                        <subviews>
+                                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1090" customClass="BWAnchoredPopUpButton">
+                                                <rect key="frame" x="4" y="2" width="32" height="19"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="32" id="Cea-BZ-g1s"/>
+                                                </constraints>
+                                                <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" alignment="center" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="1094" id="1091" customClass="BWAnchoredPopUpButtonCell">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="menu"/>
+                                                    <menu key="menu" title="OtherViews" id="1092">
+                                                        <items>
+                                                            <menuItem image="NSActionTemplate" hidden="YES" id="1094"/>
+                                                            <menuItem title="Open Details Window" keyEquivalent="i" id="1095">
+                                                                <connections>
+                                                                    <action selector="openDetailsWindow:" target="-2" id="1100"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem isSeparatorItem="YES" id="1432"/>
+                                                            <menuItem title="Reset Quick Filter" enabled="NO" id="1093">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="resetQuickFilter:" target="-2" id="1099"/>
+                                                                    <binding destination="-2" name="enabled" keyPath="hasQuickFilter" id="1098"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="New Filter from Quick Filter" enabled="NO" id="1245">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="createNewFilterFromQuickFilter:" target="-2" id="1248"/>
+                                                                    <binding destination="-2" name="enabled" keyPath="hasQuickFilter" id="1247"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem isSeparatorItem="YES" id="1433"/>
+                                                            <menuItem title="Clear Log" enabled="NO" id="1434">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="clearCurrentLog:" target="-2" id="1443"/>
+                                                                    <binding destination="-2" name="enabled" keyPath="canClearCurrentLog" id="1439"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Clear All Run Logs" enabled="NO" id="1435">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="clearAllLogs:" target="-2" id="1442"/>
+                                                                    <binding destination="-2" name="enabled" keyPath="canClearAllLogs" id="1441"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                        </items>
+                                                    </menu>
+                                                </popUpButtonCell>
+                                            </popUpButton>
+                                            <button toolTip="Show / Hide file, line and function names" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1206" customClass="BWAnchoredButton">
+                                                <rect key="frame" x="38" y="2" width="32" height="19"/>
+                                                <buttonCell key="cell" type="roundTextured" title="ƒ" bezelStyle="texturedRounded" alignment="center" controlSize="small" scrollable="YES" lineBreakMode="clipping" borderStyle="border" inset="2" id="1207" customClass="BWAnchoredButtonCell">
+                                                    <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="smallSystemBold"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <binding destination="-2" name="value" keyPath="showFunctionNames" id="1239">
+                                                        <dictionary key="options">
+                                                            <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                            <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                            <integer key="NSNullPlaceholder" value="0"/>
+                                                            <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                        </dictionary>
+                                                    </binding>
+                                                </connections>
+                                            </button>
+                                            <textField toolTip="Number of messages displayed" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="488">
+                                                <rect key="frame" x="76" y="5" width="529" height="14"/>
+                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" id="489">
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                </textFieldCell>
+                                                <connections>
+                                                    <binding destination="-2" name="value" keyPath="info" id="859">
+                                                        <dictionary key="options">
+                                                            <string key="NSNullPlaceholder">Logs from unidentified source</string>
+                                                        </dictionary>
+                                                    </binding>
+                                                </connections>
+                                            </textField>
+                                            <popUpButton toolTip="Refine filter to display only messages with the selected level and/or tag" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="894">
+                                                <rect key="frame" x="611" y="2" width="165" height="19"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="165" id="Bxl-8l-eHo"/>
+                                                </constraints>
+                                                <popUpButtonCell key="cell" type="roundRect" bezelStyle="roundedRect" imagePosition="below" alignment="center" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" pullsDown="YES" preferredEdge="maxX" selectedItem="900" id="895">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                    <menu key="menu" title="OtherViews" id="896">
+                                                        <items>
+                                                            <menuItem hidden="YES" id="900">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="916"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="All Levels" keyEquivalent="=" id="915">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="917"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Level 0" tag="1" keyEquivalent="0" indentationLevel="1" id="936">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="937"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Level ≤ 1" tag="2" keyEquivalent="1" indentationLevel="1" id="908">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="918"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Level ≤ 2" tag="3" keyEquivalent="2" indentationLevel="1" id="909">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="919"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Level ≤ 3" tag="4" keyEquivalent="3" indentationLevel="1" id="910">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="920"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem title="Level ≤ 4" tag="5" keyEquivalent="4" indentationLevel="1" id="914">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterLevel:" target="-2" id="921"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                            <menuItem isSeparatorItem="YES" tag="-1" id="911"/>
+                                                            <menuItem title="All Tags" tag="-1" keyEquivalent="*" id="938">
+                                                                <connections>
+                                                                    <action selector="selectQuickFilterTag:" target="-2" id="940"/>
+                                                                </connections>
+                                                            </menuItem>
+                                                        </items>
+                                                    </menu>
+                                                </popUpButtonCell>
+                                                <connections>
+                                                    <binding destination="-2" name="selectedIndex" keyPath="logLevel" id="901">
+                                                        <dictionary key="options">
+                                                            <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                            <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                            <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                        </dictionary>
+                                                    </binding>
+                                                </connections>
+                                            </popUpButton>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="488" firstAttribute="leading" secondItem="1206" secondAttribute="trailing" constant="8" id="2Js-MC-7yC"/>
+                                            <constraint firstItem="488" firstAttribute="centerY" secondItem="493" secondAttribute="centerY" id="2q3-xI-g0l"/>
+                                            <constraint firstItem="1090" firstAttribute="centerY" secondItem="493" secondAttribute="centerY" id="4C0-f6-ug4"/>
+                                            <constraint firstAttribute="trailing" secondItem="894" secondAttribute="trailing" constant="8" id="6pc-22-7cb"/>
+                                            <constraint firstItem="1206" firstAttribute="centerY" secondItem="493" secondAttribute="centerY" id="7kp-gA-bqW"/>
+                                            <constraint firstItem="1206" firstAttribute="width" secondItem="1090" secondAttribute="width" id="B9k-oJ-sk0"/>
+                                            <constraint firstItem="1206" firstAttribute="leading" secondItem="1090" secondAttribute="trailing" constant="2" id="Gu3-x0-nZC"/>
+                                            <constraint firstAttribute="height" constant="24" id="Mhq-o5-DJw"/>
+                                            <constraint firstItem="894" firstAttribute="leading" secondItem="488" secondAttribute="trailing" constant="8" id="X8v-TG-rrD"/>
+                                            <constraint firstItem="894" firstAttribute="centerY" secondItem="493" secondAttribute="centerY" id="k1Z-Sf-fvx"/>
+                                            <constraint firstItem="1090" firstAttribute="leading" secondItem="493" secondAttribute="leading" constant="4" id="ssG-9O-ybF"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="selectedIndex">
+                                                <integer key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </customView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="477" firstAttribute="top" secondItem="457" secondAttribute="top" id="Dzg-ea-B9Y"/>
+                                    <constraint firstItem="493" firstAttribute="leading" secondItem="457" secondAttribute="leading" id="UFR-e8-i8f"/>
+                                    <constraint firstAttribute="trailing" secondItem="477" secondAttribute="trailing" id="Wgu-qd-fZk"/>
+                                    <constraint firstItem="477" firstAttribute="leading" secondItem="457" secondAttribute="leading" id="Xwk-Dz-pNb"/>
+                                    <constraint firstAttribute="bottom" secondItem="477" secondAttribute="bottom" constant="22" id="Y5x-rZ-b7P"/>
+                                    <constraint firstAttribute="bottom" secondItem="493" secondAttribute="bottom" id="bBH-LN-gcO"/>
+                                    <constraint firstAttribute="trailing" secondItem="493" secondAttribute="trailing" id="piZ-cH-Tu6"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <holdingPriorities>
+                            <real value="250"/>
+                            <real value="250"/>
+                        </holdingPriorities>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="colorIsEnabled">
+                                <bool key="value" value="YES"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="dividerCanCollapse">
+                                <bool key="value" value="NO"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="collapsiblePopupSelection">
+                                <integer key="value" value="1"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </splitView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="455" firstAttribute="top" secondItem="372" secondAttribute="top" id="86h-Q0-fID"/>
+                    <constraint firstAttribute="bottom" secondItem="455" secondAttribute="bottom" id="Aaa-0K-nBF"/>
+                    <constraint firstAttribute="trailing" secondItem="455" secondAttribute="trailing" id="KO9-jH-2jK"/>
+                    <constraint firstItem="455" firstAttribute="leading" secondItem="372" secondAttribute="leading" id="h7M-8J-ZAO"/>
+                </constraints>
+            </view>
+            <toolbar key="toolbar" implicitIdentifier="5DBD9D22-9164-4AF7-9E9B-5493625C1150" explicitIdentifier="LoggerWindowToolbar" displayMode="iconAndLabel" sizeMode="small" id="1270">
+                <allowedToolbarItems>
+                    <toolbarItem implicitItemIdentifier="C88273F1-A03E-4796-BE78-D3529CFE1C4C" label="Open" paletteLabel="Open" toolTip="Open a log file" tag="-1" image="Load" id="1324">
+                        <connections>
+                            <action selector="openDocument:" target="-1" id="1328"/>
+                        </connections>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="6294782E-4A83-4551-9D6A-CC59FA9ABC83" label="Save" paletteLabel="Save" toolTip="Save this log file" tag="-1" image="Save" id="1325">
+                        <connections>
+                            <action selector="saveDocument:" target="-1" id="1329"/>
+                        </connections>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="A2826872-EE4D-44ED-94BA-C345D69E3C78" label="Export" paletteLabel="Export" toolTip="Export this log file to text format" tag="-1" image="Export" id="1330">
+                        <connections>
+                            <action selector="saveDocumentTo:" target="-1" id="1331"/>
+                        </connections>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="7DE133D5-E674-4629-B2D2-B312C9263D42" label="Preferences" paletteLabel="Preferences" toolTip="Open the Preferences window" tag="-1" image="NSAdvanced" id="1309">
+                        <connections>
+                            <action selector="showPreferences:" target="-1" id="1311"/>
+                        </connections>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="1275"/>
+                    <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="1276"/>
+                    <toolbarItem implicitItemIdentifier="1982BF4A-3218-428E-B152-FE3A19027668" label="Quick Search" paletteLabel="Quick Search" toolTip="Refine by filtering the current filter/tag/level settings on a search term" id="1300">
+                        <size key="minSize" width="96" height="22"/>
+                        <size key="maxSize" width="162" height="22"/>
+                        <searchField key="view" wantsLayer="YES" verticalHuggingPriority="750" id="1298">
+                            <rect key="frame" x="0.0" y="14" width="117" height="22"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="1299">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <connections>
+                                    <binding destination="-2" name="value" keyPath="filterString" id="1308">
+                                        <dictionary key="options">
+                                            <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                            <bool key="NSAlwaysPresentsApplicationModalAlerts" value="YES"/>
+                                            <bool key="NSConditionallySetsEditable" value="NO"/>
+                                            <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </searchFieldCell>
+                        </searchField>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="9B2629AC-F52B-4881-AE8F-19A7A561CE6C" label="Application Runs" paletteLabel="Application Runs" id="1416">
+                        <nil key="toolTip"/>
+                        <size key="minSize" width="100" height="25"/>
+                        <size key="maxSize" width="100" height="25"/>
+                        <popUpButton key="view" verticalHuggingPriority="750" id="1410">
+                            <rect key="frame" x="0.0" y="14" width="100" height="25"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1411">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="menu"/>
+                                <menu key="menu" title="OtherViews" id="1412">
+                                    <items>
+                                        <menuItem title="Item 1" id="1413"/>
+                                        <menuItem title="Item 2" id="1414"/>
+                                        <menuItem title="Item 3" id="1415"/>
+                                    </items>
+                                </menu>
+                            </popUpButtonCell>
+                            <connections>
+                                <binding destination="-2" name="contentValues" keyPath="document.attachedLogsPopupNames" id="1419"/>
+                                <binding destination="-2" name="selectedIndex" keyPath="document.indexOfCurrentVisibleLog" previousBinding="1419" id="1424">
+                                    <dictionary key="options">
+                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                        <real key="NSNoSelectionPlaceholder" value="0.0"/>
+                                        <real key="NSNullPlaceholder" value="0.0"/>
+                                    </dictionary>
+                                </binding>
+                                <binding destination="-2" name="enabled" keyPath="shouldEnableRunsPopup" id="1430"/>
+                            </connections>
+                        </popUpButton>
+                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="NSToolbarSeparatorItem" id="1273"/>
+                </allowedToolbarItems>
+                <defaultToolbarItems>
+                    <toolbarItem reference="1324"/>
+                    <toolbarItem reference="1325"/>
+                    <toolbarItem reference="1330"/>
+                    <toolbarItem reference="1276"/>
+                    <toolbarItem reference="1416"/>
+                    <toolbarItem reference="1276"/>
+                    <toolbarItem reference="1309"/>
+                    <toolbarItem reference="1300"/>
+                </defaultToolbarItems>
+            </toolbar>
+            <connections>
+                <outlet property="delegate" destination="-2" id="913"/>
+            </connections>
+        </window>
+        <window title="Filter Editor" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="586" userLabel="Sheet (Filter Editor)">
+            <windowStyleMask key="styleMask" titled="YES" resizable="YES" texturedBackground="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="183" y="289" width="480" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <value key="minSize" type="size" width="400" height="200"/>
+            <view key="contentView" id="587">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="588">
+                        <rect key="frame" x="-1" y="60" width="482" height="162"/>
+                        <clipView key="contentView" ambiguous="YES" id="IvX-O1-SEU">
+                            <rect key="frame" x="1" y="1" width="480" height="160"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                            <subviews>
+                                <predicateEditor verticalHuggingPriority="750" ambiguous="YES" nestingMode="simple" rowHeight="25" id="591">
+                                    <rect key="frame" x="0.0" y="0.0" width="480" height="160"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <rowTemplates>
+                                        <predicateEditorRowTemplate rowType="compound" id="592">
+                                            <popUpMenus>
+                                                <menu id="604">
+                                                    <items>
+                                                        <menuItem title="Any" state="on" id="607">
+                                                            <integer key="representedObject" value="2"/>
+                                                        </menuItem>
+                                                        <menuItem title="All" id="608">
+                                                            <integer key="representedObject" value="1"/>
+                                                        </menuItem>
+                                                        <menuItem title="None" id="613">
+                                                            <integer key="representedObject" value="0"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <menu id="605">
+                                                    <items>
+                                                        <menuItem title="of the following are true" state="on" id="606"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpMenus>
+                                        </predicateEditorRowTemplate>
+                                        <predicateEditorRowTemplate rowType="simple" id="593">
+                                            <array key="leftExpressionObject">
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">messageType</string>
+                                                </expression>
+                                            </array>
+                                            <array key="rightExpressionObject">
+                                                <expression type="constant">
+                                                    <string key="constantValue">text</string>
+                                                </expression>
+                                                <expression type="constant">
+                                                    <string key="constantValue">data</string>
+                                                </expression>
+                                                <expression type="constant">
+                                                    <string key="constantValue">img</string>
+                                                </expression>
+                                            </array>
+                                            <popUpMenus>
+                                                <menu id="594">
+                                                    <items>
+                                                        <menuItem title="Message Type" state="on" id="617">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">messageType</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <menu id="595">
+                                                    <items>
+                                                        <menuItem title="is" state="on" id="599">
+                                                            <integer key="representedObject" value="4"/>
+                                                        </menuItem>
+                                                        <menuItem title="is not" id="600">
+                                                            <integer key="representedObject" value="5"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <menu id="854">
+                                                    <items>
+                                                        <menuItem title="Text" state="on" id="855">
+                                                            <expression key="representedObject" type="constant">
+                                                                <string key="constantValue">text</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Binary Data" id="856">
+                                                            <expression key="representedObject" type="constant">
+                                                                <string key="constantValue">data</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Image" id="857">
+                                                            <expression key="representedObject" type="constant">
+                                                                <string key="constantValue">img</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                            </popUpMenus>
+                                        </predicateEditorRowTemplate>
+                                        <predicateEditorRowTemplate rowType="simple" id="819">
+                                            <array key="leftExpressionObject">
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">messageText</string>
+                                                </expression>
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">tag</string>
+                                                </expression>
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">threadID</string>
+                                                </expression>
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">filename</string>
+                                                </expression>
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">functionName</string>
+                                                </expression>
+                                            </array>
+                                            <integer key="rightExpressionObject" value="700"/>
+                                            <comparisonPredicateOptions key="options" caseInsensitive="YES"/>
+                                            <popUpMenus>
+                                                <menu id="820">
+                                                    <items>
+                                                        <menuItem title="Message" state="on" id="1229">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">messageText</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Tag" id="1230">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">tag</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Thread Name" id="1231">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">threadID</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="File Name" id="1232">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">filename</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Function / Method Name" id="1233">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">functionName</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <menu id="824">
+                                                    <items>
+                                                        <menuItem title="contains" state="on" id="825">
+                                                            <integer key="representedObject" value="99"/>
+                                                        </menuItem>
+                                                        <menuItem title="begins with" id="826">
+                                                            <integer key="representedObject" value="8"/>
+                                                        </menuItem>
+                                                        <menuItem title="ends with" id="827">
+                                                            <integer key="representedObject" value="9"/>
+                                                        </menuItem>
+                                                        <menuItem title="is" id="828">
+                                                            <integer key="representedObject" value="4"/>
+                                                        </menuItem>
+                                                        <menuItem title="is not" id="829">
+                                                            <integer key="representedObject" value="5"/>
+                                                        </menuItem>
+                                                        <menuItem title="matches" id="830">
+                                                            <integer key="representedObject" value="6"/>
+                                                        </menuItem>
+                                                        <menuItem title="is like" id="831">
+                                                            <integer key="representedObject" value="7"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                            </popUpMenus>
+                                        </predicateEditorRowTemplate>
+                                        <predicateEditorRowTemplate rowType="simple" id="860">
+                                            <array key="leftExpressionObject">
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">level</string>
+                                                </expression>
+                                                <expression type="keyPath">
+                                                    <string key="keyPath">lineNumber</string>
+                                                </expression>
+                                            </array>
+                                            <integer key="rightExpressionObject" value="300"/>
+                                            <popUpMenus>
+                                                <menu id="861">
+                                                    <items>
+                                                        <menuItem title="Log Level" state="on" id="1234">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">level</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                        <menuItem title="Line Number" id="1235">
+                                                            <expression key="representedObject" type="keyPath">
+                                                                <string key="keyPath">lineNumber</string>
+                                                            </expression>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                                <menu id="865">
+                                                    <items>
+                                                        <menuItem title="is" state="on" id="869">
+                                                            <integer key="representedObject" value="4"/>
+                                                        </menuItem>
+                                                        <menuItem title="is not" id="870">
+                                                            <integer key="representedObject" value="5"/>
+                                                        </menuItem>
+                                                        <menuItem title="is greater than or equal to" id="875">
+                                                            <integer key="representedObject" value="3"/>
+                                                        </menuItem>
+                                                        <menuItem title="is less than or equal to" id="876">
+                                                            <integer key="representedObject" value="1"/>
+                                                        </menuItem>
+                                                        <menuItem title="is less than" id="877">
+                                                            <integer key="representedObject" value="0"/>
+                                                        </menuItem>
+                                                        <menuItem title="is greater than" id="878">
+                                                            <integer key="representedObject" value="2"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                            </popUpMenus>
+                                        </predicateEditorRowTemplate>
+                                    </rowTemplates>
+                                </predicateEditor>
+                            </subviews>
+                            <color key="backgroundColor" white="0.91000002619999998" alpha="1" colorSpace="calibratedWhite"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="590">
+                            <rect key="frame" x="-100" y="-100" width="360" height="15"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="589">
+                            <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="609">
+                        <rect key="frame" x="370" y="12" width="96" height="32"/>
+                        <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="610">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="validateFilterEdition:" target="-2" id="816"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="611">
+                        <rect key="frame" x="274" y="12" width="96" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="612">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="cancelFilterEdition:" target="-2" id="817"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="688">
+                        <rect key="frame" x="102" y="231" width="358" height="22"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="filter name" drawsBackground="YES" id="689">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="690">
+                        <rect key="frame" x="17" y="233" width="81" height="17"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Filter Name:" id="691">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+            </view>
+        </window>
+        <window title="New Mark" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="1104" userLabel="Sheet (Add Mark)">
+            <windowStyleMask key="styleMask" titled="YES" texturedBackground="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="183" y="448" width="480" height="111"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" id="1105">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="111"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1107">
+                        <rect key="frame" x="94" y="72" width="366" height="22"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Mark title" drawsBackground="YES" id="1114">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1108">
+                        <rect key="frame" x="17" y="74" width="72" height="17"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="New mark:" id="1113">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1110">
+                        <rect key="frame" x="370" y="12" width="96" height="32"/>
+                        <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1111">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="validateAddMark:" target="-2" id="1162"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1109">
+                        <rect key="frame" x="269" y="12" width="96" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1112">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="cancelAddMark:" target="-2" id="1163"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+        </window>
+        <arrayController automaticallyRearrangesObjects="YES" id="963" userLabel="Filter Sets Array Controller">
+            <declaredKeys>
+                <string>filters</string>
+                <string>title</string>
+                <string>uid</string>
+            </declaredKeys>
+            <connections>
+                <binding destination="-3" name="contentArray" keyPath="delegate.filterSets" id="969"/>
+                <binding destination="-3" name="sortDescriptors" keyPath="delegate.filtersSortDescriptors" id="983"/>
+            </connections>
+        </arrayController>
+        <arrayController automaticallyRearrangesObjects="YES" id="532" userLabel="Filter Array Controller">
+            <declaredKeys>
+                <string>title</string>
+                <string>predicate</string>
+                <string>uid</string>
+            </declaredKeys>
+            <connections>
+                <binding destination="-3" name="sortDescriptors" keyPath="delegate.filtersSortDescriptors" id="990"/>
+                <binding destination="963" name="contentArray" keyPath="selection.filters" id="996"/>
+            </connections>
+        </arrayController>
+        <userDefaultsController representsSharedInstance="YES" id="1426"/>
+    </objects>
+    <resources>
+        <image name="Export" width="32" height="32"/>
+        <image name="Load" width="48" height="48"/>
+        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSAdvanced" width="32" height="32"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="Save" width="48" height="48"/>
+    </resources>
+</document>


### PR DESCRIPTION
Using autolayout in the Loggerwindow fixes an error around having more than one logger window. 
In that scenario, one of the windows used to lose the bottom bar, and the main log table was not resizing accordingly.
