### PR TITLE
Enable Advanced Colors per level

### DIFF
--- a/Desktop Viewer/Classes/LoggerMessage.m
+++ b/Desktop Viewer/Classes/LoggerMessage.m
@@ -314,7 +314,6 @@ static NSMutableArray *sTags = nil;
 	td->tv_usec = (__darwin_suseconds_t)((t - (double)td->tv_sec) * 1000000.0);
 }
 
-#ifdef DEBUG
 -(NSString *)description
 {
 	NSString *typeString = ((type == LOGMSG_TYPE_LOG) ? @"Log" :
@@ -335,6 +334,5 @@ static NSMutableArray *sTags = nil;
 	return [NSString stringWithFormat:@"<%@ %p seq=%d type=%@ thread=%@ tag=%@ level=%d message=%@>",
 			[self class], self, sequence, typeString, threadID, tag, (int)level, desc];
 }
-#endif
 
 @end

--- a/Desktop Viewer/Classes/LoggerMessageCell.m
+++ b/Desktop Viewer/Classes/LoggerMessageCell.m
@@ -354,7 +354,7 @@ NSString * const kMessageColumnWidthsChangedNotification = @"MessageColumnWidths
 
 + (NSColor *)colorForMessage:(LoggerMessage *)message
 {
-    return [self colorForString:[message message]];
+    return [self colorForString:message.description];
 }
 
 #pragma mark -


### PR DESCRIPTION
#169 broke a great feature: setting a color per level. This commit restores this feature. It is now possible to define the following advanced colors:

Comment  | Regular Expression | Color
-------- | ------------------ | -----
Warnings | level=1            | bold orange
Errors   | level=0            | bold red