### PR TITLE
Peer-to-peer browsing

### DIFF
--- a/Desktop Viewer/Classes/LoggerConnection.m
+++ b/Desktop Viewer/Classes/LoggerConnection.m
@@ -306,7 +306,9 @@ char sConnectionAssociatedObjectKey = 1;
 {
 	// enforce thread safety (only on main thread)
 	assert([NSThread isMainThread]);
-	return [NSString stringWithFormat:@"%@ @ %@", [self clientAppDescription], [self clientAddressDescription]];
+	NSString *clientAppDescription = [self clientAppDescription];
+	NSString *clientAddressDescription = [self clientAddressDescription];
+	return clientAddressDescription ? [NSString stringWithFormat:@"%@ @ %@", clientAppDescription, clientAddressDescription] : clientAppDescription;
 }
 
 - (NSString *)status

--- a/Desktop Viewer/Classes/LoggerIPConnection.m
+++ b/Desktop Viewer/Classes/LoggerIPConnection.m
@@ -36,28 +36,23 @@
 
 - (NSString *)clientAddressDescription
 {
-	if ([clientAddress length] == sizeof(struct sockaddr_in6))
+	int family;
+	const void *address = NULL;
+	char ip[INET6_ADDRSTRLEN];
+	socklen_t size;
+	if (clientAddress.length == sizeof(struct sockaddr_in6))
 	{
-		struct sockaddr_in6 addr6;
-		[clientAddress getBytes:&addr6 length:sizeof(addr6)];
-		return [NSString stringWithFormat:@"%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x",
-				addr6.sin6_addr.__u6_addr.__u6_addr16[0],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[1],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[2],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[3],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[4],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[5],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[6],
-				addr6.sin6_addr.__u6_addr.__u6_addr16[7]];
+		family = AF_INET6;
+		size = INET6_ADDRSTRLEN;
+		address = clientAddress.bytes + offsetof(struct sockaddr_in6, sin6_addr);
 	}
-
-	struct sockaddr_in addr4;
-	[clientAddress getBytes:&addr4 length:sizeof(addr4)];
-	char *inetname = inet_ntoa(addr4.sin_addr);
-	if (inetname != NULL)
-		return [NSString stringWithCString:inetname encoding:NSASCIIStringEncoding];
-
-	return nil;
+	else if (clientAddress.length == sizeof(struct sockaddr_in))
+	{
+		family = AF_INET;
+		size = INET_ADDRSTRLEN;
+		address = clientAddress.bytes + offsetof(struct sockaddr_in, sin_addr);
+	}
+	return address != NULL && inet_ntop(family, address, ip, size) ? @(ip) : nil;
 }
 
 @end

--- a/Desktop Viewer/Classes/LoggerTCPTransport.m
+++ b/Desktop Viewer/Classes/LoggerTCPTransport.m
@@ -412,13 +412,11 @@ static void AcceptSocketCallback(CFSocketRef sock, CFSocketCallBackType type, CF
 	LoggerAppDelegate *appDelegate = (LoggerAppDelegate *)[[NSApplication sharedApplication] delegate];
 	if (!appDelegate.serverCertsLoadAttempted)
 	{
-		dispatch_async(dispatch_get_main_queue(), ^{
-			NSError *error = nil;
-			if (![appDelegate loadEncryptionCertificate:&error])
-			{
-				[NSApp presentError:error];
-			}
-		});
+		NSError *error = nil;
+		if (![appDelegate loadEncryptionCertificate:&error])
+		{
+			[NSApp performSelectorOnMainThread:@selector(presentError:) withObject:error waitUntilDone:NO];
+		}
 	}
 	return (appDelegate.serverCerts != NULL);
 }

--- a/Desktop Viewer/Classes/LoggerTransport.m
+++ b/Desktop Viewer/Classes/LoggerTransport.m
@@ -72,7 +72,7 @@
 {
 	// make a new document for a connection (it is considered live once we have received
 	// the ClientInfo message) or reuse an existing document if this is a reconnection
-	dispatch_sync(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^{
 		if (!aConnection.attachedToWindow)
 			[(LoggerAppDelegate *)[NSApp delegate] newConnection:aConnection fromTransport:self];
 	});


### PR DESCRIPTION
This pull requests implements peer-to-peer browsing so that you can use NSLogger between a client and the desktop viewer even if they are not both connected to the same Wi-Fi network.

- [x] Implement peer-to-peer on the client
- [x] Implement peer-to-peer on the server
- [ ] Get the client address inside `netService:didAcceptConnectionWithInputStream:inputStream outputStream:`

As stated in 8f4f668b297620ec304d7c2b2f6e2118c9d46393:
> The only way to get peer-to-peer browsing without undocumented API is with the NSNetServiceBrowser class. This would require a big rewrite of LoggerClient.m and make `ALLOW_COCOA_USE` pretty much mandatory.

@fpillet What are your thoughts about using an undocumented API vs rewriting LoggerClient.m with NSNetServiceBrowser and dropping ALLOW_COCOA_USE?