### PR TITLE
Swiftier NSLogger

### DIFF
--- a/Client/iOS/LoggerClient.h
+++ b/Client/iOS/LoggerClient.h
@@ -221,28 +221,28 @@ extern void LogMarkerTo(Logger *logger, NSString *text) NSLOGGER_NOSTRIP;
 NSLOGGER_IGNORE_NULLABILITY_END
     
 // Swift fastpath logging functions
-extern void LogMessage_fast(NSString * _Nullable filename,
-                            NSInteger lineNumber,
-                            NSString * _Nullable functionName,
-                            NSString * _Nullable domain,
-                            NSInteger level,
-                            NSString * _Nonnull message) NSLOGGER_NOSTRIP;
+extern void LogMessage_noFormat(NSString * _Nullable filename,
+                                NSInteger lineNumber,
+                                NSString * _Nullable functionName,
+                                NSString * _Nullable domain,
+                                NSInteger level,
+                                NSString * _Nonnull message) NSLOGGER_NOSTRIP;
     
-extern void LogImage_fast(NSString * _Nullable filename,
-                          NSInteger lineNumber,
-                          NSString * _Nullable functionName,
-                          NSString * _Nullable domain,
-                          NSInteger level,
-                          NSInteger width,
-                          NSInteger height,
-                          NSData * _Nonnull data) NSLOGGER_NOSTRIP;
+extern void LogImage_noFormat(NSString * _Nullable filename,
+                              NSInteger lineNumber,
+                              NSString * _Nullable functionName,
+                              NSString * _Nullable domain,
+                              NSInteger level,
+                              NSInteger width,
+                              NSInteger height,
+                              NSData * _Nonnull data) NSLOGGER_NOSTRIP;
     
-extern void LogData_fast(NSString * _Nullable filename,
-                         NSInteger lineNumber,
-                         NSString * _Nullable functionName,
-                         NSString * _Nullable domain,
-                         NSInteger level,
-                         NSData * _Nonnull data) NSLOGGER_NOSTRIP;
+extern void LogData_noFormat(NSString * _Nullable filename,
+                             NSInteger lineNumber,
+                             NSString * _Nullable functionName,
+                             NSString * _Nullable domain,
+                             NSInteger level,
+                             NSData * _Nonnull data) NSLOGGER_NOSTRIP;
 
 #ifdef __cplusplus
 };

--- a/Client/iOS/LoggerClient.h
+++ b/Client/iOS/LoggerClient.h
@@ -90,6 +90,15 @@ extern "C" {
 #else
 #define NSLOGGER_NOSTRIP
 #endif
+    
+#define NSLOGGER_IGNORE_NULLABILITY_BEGIN \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wnullability-completeness\"")
+    
+#define NSLOGGER_IGNORE_NULLABILITY_END \
+    _Pragma("clang diagnostic pop")
+    
+NSLOGGER_IGNORE_NULLABILITY_BEGIN
 
 // Set the default logger which will be the one used when passing NULL for logge
 extern void LoggerSetDefaultLogger(Logger *aLogger) NSLOGGER_NOSTRIP;
@@ -208,6 +217,32 @@ extern void LogEndBlockTo(Logger *logger) NSLOGGER_NOSTRIP;
 // Log a marker (text can be null)
 extern void LogMarker(NSString *text) NSLOGGER_NOSTRIP;
 extern void LogMarkerTo(Logger *logger, NSString *text) NSLOGGER_NOSTRIP;
+    
+NSLOGGER_IGNORE_NULLABILITY_END
+    
+// Swift fastpath logging functions
+extern void LogMessage_fast(NSString * _Nullable filename,
+                            NSInteger lineNumber,
+                            NSString * _Nullable functionName,
+                            NSString * _Nullable domain,
+                            NSInteger level,
+                            NSString * _Nonnull message) NSLOGGER_NOSTRIP;
+    
+extern void LogImage_fast(NSString * _Nullable filename,
+                          NSInteger lineNumber,
+                          NSString * _Nullable functionName,
+                          NSString * _Nullable domain,
+                          NSInteger level,
+                          NSInteger width,
+                          NSInteger height,
+                          NSData * _Nonnull data) NSLOGGER_NOSTRIP;
+    
+extern void LogData_fast(NSString * _Nullable filename,
+                         NSInteger lineNumber,
+                         NSString * _Nullable functionName,
+                         NSString * _Nullable domain,
+                         NSInteger level,
+                         NSData * _Nonnull data) NSLOGGER_NOSTRIP;
 
 #ifdef __cplusplus
 };

--- a/Client/iOS/LoggerClient.m
+++ b/Client/iOS/LoggerClient.m
@@ -2716,12 +2716,12 @@ static void LogMessageTo_internal(Logger *logger,
     }
 }
 
-void LogMessage_fast(NSString *filename,
-                     NSInteger lineNumber,
-                     NSString *functionName,
-                     NSString *domain,
-                     NSInteger level,
-                     NSString *message)
+void LogMessage_noFormat(NSString *filename,
+                         NSInteger lineNumber,
+                         NSString *functionName,
+                         NSString *domain,
+                         NSInteger level,
+                         NSString *message)
 {
     Logger *logger = LoggerStart(NULL);	// start if needed
     if (logger != NULL)
@@ -2805,14 +2805,14 @@ static void LogImageTo_internal(Logger *logger,
 	}
 }
 
-void LogImage_fast(NSString *filename,
-                   NSInteger lineNumber,
-                   NSString *functionName,
-                   NSString *domain,
-                   NSInteger level,
-                   NSInteger width,
-                   NSInteger height,
-                   NSData *data)
+void LogImage_noFormat(NSString *filename,
+                       NSInteger lineNumber,
+                       NSString *functionName,
+                       NSString *domain,
+                       NSInteger level,
+                       NSInteger width,
+                       NSInteger height,
+                       NSData *data)
 {
     Logger *logger = LoggerStart(NULL);		// start if needed
     if (logger != NULL)
@@ -2892,12 +2892,12 @@ static void LogDataTo_internal(Logger *logger,
     }
 }
 
-void LogData_fast(NSString *filename,
-                  NSInteger lineNumber,
-                  NSString *functionName,
-                  NSString *domain,
-                  NSInteger level,
-                  NSData *data)
+void LogData_noFormat(NSString *filename,
+                      NSInteger lineNumber,
+                      NSString *functionName,
+                      NSString *domain,
+                      NSInteger level,
+                      NSData *data)
 {
     Logger *logger = LoggerStart(NULL);		// start if needed
     if (logger != NULL)

--- a/Client/iOS/LoggerClient.m
+++ b/Client/iOS/LoggerClient.m
@@ -2339,6 +2339,14 @@ static void LoggerMessageFinalize(CFMutableDataRef encoder)
 	}
 }
 
+static void LoggerMessageAddInteger(CFMutableDataRef encoder, NSInteger anInt, int key) {
+#if __LP64__
+    LoggerMessageAddInt64(encoder, anInt, key);
+#else
+    LoggerMessageAddInt32(encoder, anInt, key);
+#endif
+}
+
 static void LoggerMessageAddInt32(CFMutableDataRef encoder, int32_t anInt, int key)
 {
 	uint8_t *p = LoggerMessagePrepareForPart(encoder, 6);
@@ -2708,6 +2716,47 @@ static void LogMessageTo_internal(Logger *logger,
     }
 }
 
+void LogMessage_fast(NSString *filename,
+                     NSInteger lineNumber,
+                     NSString *functionName,
+                     NSString *domain,
+                     NSInteger level,
+                     NSString *message)
+{
+    Logger *logger = LoggerStart(NULL);	// start if needed
+    if (logger != NULL)
+    {
+        int32_t seq = OSAtomicIncrement32Barrier(&logger->messageSeq);
+        LOGGERDBG2(CFSTR("%ld LogMessage"), seq);
+        
+        CFMutableDataRef encoder = LoggerMessageCreate(seq);
+        if (encoder != NULL)
+        {
+            LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
+            if (domain != nil && [domain length])
+                LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+            if (level)
+                LoggerMessageAddInteger(encoder, level, PART_KEY_LEVEL);
+            if (filename != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)filename, PART_KEY_FILENAME);
+            if (lineNumber)
+                LoggerMessageAddInteger(encoder, lineNumber, PART_KEY_LINENUMBER);
+            if (functionName != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)functionName, PART_KEY_FUNCTIONNAME);
+            
+            LoggerMessageAddString(encoder, (CFStringRef)message, PART_KEY_MESSAGE);
+            
+            LoggerMessageFinalize(encoder);
+            LoggerPushMessageToQueue(logger, encoder);
+            CFRelease(encoder);
+        }
+        else
+        {
+            LOGGERDBG2(CFSTR("-> failed creating encoder"));
+        }
+    }
+}
+
 static void LogImageTo_internal(Logger *logger,
 								const char *filename,
 								int lineNumber,
@@ -2756,6 +2805,53 @@ static void LogImageTo_internal(Logger *logger,
 	}
 }
 
+void LogImage_fast(NSString *filename,
+                   NSInteger lineNumber,
+                   NSString *functionName,
+                   NSString *domain,
+                   NSInteger level,
+                   NSInteger width,
+                   NSInteger height,
+                   NSData *data)
+{
+    Logger *logger = LoggerStart(NULL);		// start if needed
+    if (logger != NULL)
+    {
+        int32_t seq = OSAtomicIncrement32Barrier(&logger->messageSeq);
+        LOGGERDBG2(CFSTR("%ld LogImage"), seq);
+        
+        CFMutableDataRef encoder = LoggerMessageCreate(seq);
+        if (encoder != NULL)
+        {
+            LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
+            if (domain != nil && [domain length])
+                LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+            if (level)
+                LoggerMessageAddInteger(encoder, level, PART_KEY_LEVEL);
+            if (width && height)
+            {
+                LoggerMessageAddInteger(encoder, width, PART_KEY_IMAGE_WIDTH);
+                LoggerMessageAddInteger(encoder, height, PART_KEY_IMAGE_HEIGHT);
+            }
+            if (filename != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)filename, PART_KEY_FILENAME);
+            if (lineNumber)
+                LoggerMessageAddInteger(encoder, lineNumber, PART_KEY_LINENUMBER);
+            if (functionName != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)functionName, PART_KEY_FUNCTIONNAME);
+            LoggerMessageAddData(encoder, (CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_IMAGE);
+            
+            LoggerMessageFinalize(encoder);
+            LoggerPushMessageToQueue(logger, encoder);
+            CFRelease(encoder);
+        }
+        else
+        {
+            LOGGERDBG2(CFSTR("-> failed creating encoder"));
+        }
+    }
+}
+
 static void LogDataTo_internal(Logger *logger,
 							   const char *filename,
 							   int lineNumber,
@@ -2786,6 +2882,46 @@ static void LogDataTo_internal(Logger *logger,
             LoggerMessageAddData(encoder, (CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_BINARY);
 
 			LoggerMessageFinalize(encoder);
+            LoggerPushMessageToQueue(logger, encoder);
+            CFRelease(encoder);
+        }
+        else
+        {
+            LOGGERDBG2(CFSTR("-> failed creating encoder"));
+        }
+    }
+}
+
+void LogData_fast(NSString *filename,
+                  NSInteger lineNumber,
+                  NSString *functionName,
+                  NSString *domain,
+                  NSInteger level,
+                  NSData *data)
+{
+    Logger *logger = LoggerStart(NULL);		// start if needed
+    if (logger != NULL)
+    {
+        int32_t seq = OSAtomicIncrement32Barrier(&logger->messageSeq);
+        LOGGERDBG2(CFSTR("%ld LogData"), seq);
+        
+        CFMutableDataRef encoder = LoggerMessageCreate(seq);
+        if (encoder != NULL)
+        {
+            LoggerMessageAddInt32(encoder, LOGMSG_TYPE_LOG, PART_KEY_MESSAGE_TYPE);
+            if (domain != nil && [domain length])
+                LoggerMessageAddString(encoder, (CFStringRef)domain, PART_KEY_TAG);
+            if (level)
+                LoggerMessageAddInteger(encoder, level, PART_KEY_LEVEL);
+            if (filename != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)filename, PART_KEY_FILENAME);
+            if (lineNumber)
+                LoggerMessageAddInteger(encoder, lineNumber, PART_KEY_LINENUMBER);
+            if (functionName != NULL)
+                LoggerMessageAddString(encoder, (CFStringRef)functionName, PART_KEY_FUNCTIONNAME);
+            LoggerMessageAddData(encoder, (CFDataRef)data, PART_KEY_MESSAGE, PART_TYPE_BINARY);
+            
+            LoggerMessageFinalize(encoder);
             LoggerPushMessageToQueue(logger, encoder);
             CFRelease(encoder);
         }

--- a/Client/iOS/NSLogger.swift
+++ b/Client/iOS/NSLogger.swift
@@ -124,7 +124,7 @@ public final class Logger {
                     _ line: Int = #line,
                     _ function: String = #function) {
         whenEnabled {
-            LogMessage_fast(file, line, function, domain.rawValue, level.rawValue, message())
+            LogMessage_noFormat(file, line, function, domain.rawValue, level.rawValue, message())
         }
     }
     
@@ -136,7 +136,7 @@ public final class Logger {
                     _ function: String = #function) {
         whenEnabled {
             guard let rawImage = imageData(image()) else { return }
-            LogImage_fast(file, line, function, domain.rawValue, level.rawValue, rawImage.width, rawImage.height, rawImage.data)
+            LogImage_noFormat(file, line, function, domain.rawValue, level.rawValue, rawImage.width, rawImage.height, rawImage.data)
         }
     }
     
@@ -147,7 +147,7 @@ public final class Logger {
                     _ line: Int = #line,
                     _ function: String = #function) {
         whenEnabled {
-            LogData_fast(file, line, function, domain.rawValue, level.rawValue, data())
+            LogData_noFormat(file, line, function, domain.rawValue, level.rawValue, data())
         }
     }
 }

--- a/Client/iOS/NSLogger.swift
+++ b/Client/iOS/NSLogger.swift
@@ -39,142 +39,117 @@ import Foundation
 #if os(iOS) || os(tvOS)
 
 import UIKit
+    
+public typealias Image = UIImage
 
 #endif
 #if os(OSX)
 
 import Cocoa
+public typealias Image = NSImage
 
 #endif
 
-public enum LoggerDomain {
-	case App
-	case View
-	case Layout
-	case Controller
-	case Routing
-	case Service
-	case Network
-	case Model
-	case Cache
-	case DB
-	case IO
-	case Custom(String)
 
-	var rawValue: String {
-		switch self {
-			case .App: return "App"
-			case .View: return "View"
-			case .Layout: return "Layout"
-			case .Controller: return "Controller"
-			case .Routing: return "Routing"
-			case .Service: return "Service"
-			case .Network: return "Network"
-			case .Model: return "Model"
-			case .Cache: return "Cache"
-			case .DB: return "DB"
-			case .IO: return "IO"
-			case let .Custom(customDomain): return customDomain
-		}
-	}
-}
-
-public enum LoggerLevel: Int32 {
-	case Error = 0
-	case Warning = 1
-	case Important = 2
-	case Info = 3
-	case Debug = 4
-	case Verbose = 5
-	case Noise = 6
-}
-
-/*
-* Log a string to display in the viewer
-*
-*/
-public func Log(_ domain: LoggerDomain, _ level: LoggerLevel, _ format: @autoclosure () -> String,
-				_ filename: String = #file, lineNumber: Int32 = #line, fnName: String = #function) {
-#if !NSLOGGER_DISABLED || NSLOGGER_ENABLED
-	let vaArgs = getVaList([format()])
-
-	let fileNameCstr = stringToCStr(filename)
-	let fnNameCstr = stringToCStr(fnName)
-
-	LogMessageF_va(fileNameCstr, lineNumber, fnNameCstr,
-				   domain.rawValue, level.rawValue,
-				   "%@", vaArgs)
-
-#endif
-}
-
-/*
-* Log an iOS / tvOS UIImage to display in the viewer
-*
-*/
-#if os(iOS) || os(tvOS)
-
-public func LogImage(_ domain: LoggerDomain, _ level: LoggerLevel, _ image: @autoclosure () -> UIImage,
-					 _ filename: String = #file, lineNumber: Int32 = #line, fnName: String = #function) {
-#if !NSLOGGER_DISABLED || NSLOGGER_ENABLED
-	let image = image()
-	let imageData = UIImagePNGRepresentation(image)
-	let fileNameCstr = stringToCStr(filename)
-	let fnNameCstr = stringToCStr(fnName)
-	LogImageDataF(fileNameCstr, lineNumber, fnNameCstr,
-				  domain.rawValue, level.rawValue,
-				  Int32(image.size.width), Int32(image.size.height), imageData)
-#endif
-}
-
-#endif
-
-/*
-* Log a macOS NSImage to display in the viewer
-*
-*/
-#if os(OSX)
-
-public func LogImage(_ domain: LoggerDomain, _ level: LoggerLevel, _ image: @autoclosure () -> NSImage,
-					 _ filename: String = #file, lineNumber: Int32 = #line, fnName: String = #function) {
-#if !NSLOGGER_DISABLED || NSLOGGER_ENABLED
-	let image = image()
-	let width = image.size.width
-	let height = image.size.height
-	guard
-		let tiff = image.tiffRepresentation,
-		let bitmapRep = NSBitmapImageRep(data: tiff),
-		let imageData = bitmapRep.representation(using: NSPNGFileType, properties: [:]) else {
-		return
-	}
-	let fileNameCstr = stringToCStr(filename)
-	let fnNameCstr = stringToCStr(fnName)
-	LogImageDataF(fileNameCstr, lineNumber, fnNameCstr,
-				  domain.rawValue, level.rawValue,
-				  Int32(width), Int32(height), imageData)
-#endif
-}
-
-#endif
-
-/*
-* Log a binary block of data to a binary representation in the viewer
-*
-*/
-public func LogData(filename: String, lineNumber: Int32, functionName: String,
-					domain: LoggerDomain, level: LoggerLevel, data: @autoclosure () -> Data) {
-#if !NSLOGGER_DISABLED || NSLOGGER_ENABLED
-	let fileNameCstr = stringToCStr(filename)
-	let functionNameCstr = stringToCStr(functionName)
-	LogDataF(fileNameCstr, lineNumber, functionNameCstr,
-			 domain.rawValue, level.rawValue, data())
-#endif
-}
-
-
-fileprivate func stringToCStr(_ string: String) -> UnsafePointer<Int8> {
-	let cfStr = string as NSString
-	return cfStr.cString(using: String.Encoding.ascii.rawValue)!
+/// The main NSLogger class, use `shared` property to obtain an instance
+public final class Logger {
+    
+    /// The current NSLogger
+    public static let shared = Logger()
+    
+    private init() {}
+    
+    public struct Domain: RawRepresentable {
+        public let rawValue: String
+        public init(rawValue: String) { self.rawValue = rawValue }
+        
+        public static let app = Domain(rawValue: "App")
+        public static let view = Domain(rawValue: "View")
+        public static let layout = Domain(rawValue: "Layout")
+        public static let controller = Domain(rawValue: "Controller")
+        public static let routing = Domain(rawValue: "Routing")
+        public static let service = Domain(rawValue: "Service")
+        public static let network = Domain(rawValue: "Network")
+        public static let model = Domain(rawValue: "Model")
+        public static let cache = Domain(rawValue: "Cache")
+        public static let db = Domain(rawValue: "DB")
+        public static let io = Domain(rawValue: "IO")
+        
+        public static func custom(_ value: String) -> Domain {
+            return Domain(rawValue: value)
+        }
+    }
+    public struct Level: RawRepresentable {
+        
+        public let rawValue: Int
+        public init(rawValue: Int) { self.rawValue = rawValue }
+        
+        public static let error = Level(rawValue: 0)
+        public static let warning = Level(rawValue: 1)
+        public static let important = Level(rawValue: 2)
+        public static let info = Level(rawValue: 3)
+        public static let debug = Level(rawValue: 4)
+        public static let verbose = Level(rawValue: 5)
+        public static let noise = Level(rawValue: 6)
+        
+        public static func custom(_ value: Int) -> Level {
+            return Level(rawValue: value)
+        }
+    }
+    
+    private func imageData(_ image: Image) -> (data: Data, width: Int, height: Int)? {
+        #if os(iOS) || os(tvOS)
+            guard let imageData = UIImagePNGRepresentation(image) else { return nil }
+            return (imageData, Int(image.size.width), Int(image.size.height))
+        #elseif os(OSX)
+            guard let tiff = image.tiffRepresentation,
+                let bitmapRep = NSBitmapImageRep(data: tiff),
+                let imageData = bitmapRep.representation(using: NSPNGFileType, properties: [:]) else { return nil }
+            return (imageData, Int(image.size.width), Int(image.size.height))
+        #else
+            "CompilationError: OS not handled !"
+        #endif
+    }
+    
+    private func whenEnabled(then execute: () -> Void) {
+        #if !NSLOGGER_DISABLED || NSLOGGER_ENABLED
+            execute()
+        #endif
+    }
+    
+    public func log(_ domain: Domain,
+                    _ level: Level,
+                    _ message: @autoclosure () -> String,
+                    _ file: String = #file,
+                    _ line: Int = #line,
+                    _ function: String = #function) {
+        whenEnabled {
+            LogMessage_fast(file, line, function, domain.rawValue, level.rawValue, message())
+        }
+    }
+    
+    public func log(_ domain: Domain,
+                    _ level: Level,
+                    _ image: @autoclosure () -> Image,
+                    _ file: String = #file,
+                    _ line: Int = #line,
+                    _ function: String = #function) {
+        whenEnabled {
+            guard let rawImage = imageData(image()) else { return }
+            LogImage_fast(file, line, function, domain.rawValue, level.rawValue, rawImage.width, rawImage.height, rawImage.data)
+        }
+    }
+    
+    public func log(_ domain: Domain,
+                    _ level: Level,
+                    _ data: @autoclosure () -> Data,
+                    _ file: String = #file,
+                    _ line: Int = #line,
+                    _ function: String = #function) {
+        whenEnabled {
+            LogData_fast(file, line, function, domain.rawValue, level.rawValue, data())
+        }
+    }
 }
 
 

--- a/NSLogger.podspec
+++ b/NSLogger.podspec
@@ -28,10 +28,11 @@ Pod::Spec.new do |s|
   #
   s.subspec 'ObjC' do |ss|
     ss.source_files = 'Client/iOS/*.{h,m}'
-	ss.public_header_files = 'Client/iOS/*.h'
-	ss.ios.frameworks = 'CFNetwork', 'SystemConfiguration', 'UIKit'
-	ss.osx.frameworks = 'CFNetwork', 'SystemConfiguration', 'CoreServices', 'AppKit'
+    ss.public_header_files = 'Client/iOS/*.h'
+    ss.ios.frameworks = 'CFNetwork', 'SystemConfiguration', 'UIKit'
+    ss.osx.frameworks = 'CFNetwork', 'SystemConfiguration', 'CoreServices', 'AppKit'
     ss.xcconfig = {
+      'OTHER_CFLAGS' => '-Wno-nullability-completeness',
       'GCC_PREPROCESSOR_DEFINITIONS' => '${inherited} NSLOGGER_WAS_HERE=1 NSLOGGER_BUILD_USERNAME="${USER}"'
     }
   end
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   # you can define a NSLOGGER_ENABLED flag which forces calling into the framework.
   #
   s.subspec 'Swift' do |ss|
-	ss.dependency 'NSLogger/ObjC'
+    ss.dependency 'NSLogger/ObjC'
     ss.source_files = 'Client/iOS/*.swift'
     ss.pod_target_xcconfig = {
         'OTHER_SWIFT_FLAGS[config=Release]' => '$(inherited) -DNSLOGGER_DISABLED'
@@ -59,7 +60,7 @@ Pod::Spec.new do |s|
   # 'NSLogger' pod, add 'NSLogger/Swift' as needed.
   #
   s.subspec 'NoStrip' do |ss|
-  	ss.dependency 'NSLogger/ObjC'
+    ss.dependency 'NSLogger/ObjC'
     ss.xcconfig = {
       'GCC_PREPROCESSOR_DEFINITIONS' => '${inherited} NSLOGGER_ALLOW_NOSTRIP=1'
     }

--- a/README.markdown
+++ b/README.markdown
@@ -56,10 +56,19 @@ import NSLogger
 
 […]
 
-Log(.Network, .Info, "Checking paper level…")
-Log(.Network, .Error, "Oups! " + "No more paper. 🐞")
-LogImage(.View, .Noise, myPrettyImage)
-LogData(.Custom("My Domain"), .Noise, someDataObject)
+// logging some messages
+Logger.shared.log(.network, .info, "Checking paper level…")
+
+// shorter static function way
+fileprivate let log = Logger.shared.log
+log(.network, .error, "Oups! " + "No more paper. 🐞")
+
+// logging image
+Logger.shared.log(.view, .noise, myPrettyImage)
+
+// logging data
+Logger.shared.log(.custom("My Domain"), .noise, someDataObject)
+
 ```
 
 **Objective-C** wrapper API:


### PR DESCRIPTION
List of features / changes

- Added _fast C functions to have a straight logging path when logging from swift 
   - no formatting with vaargs
   - not using String -> CString -> UTF8String transforms
   - using NSInteger function in order to use native Swift Ints
   - Provide nullability annotations to have clean swift interfaces

- Providing a wrapper using swift3+ guidelines: 
   - `camelCase` members instead of `UpperCamelCase`
   - Everything wrapped in a single class instead of top-level functions
