### PR TITLE
Fix carthage inconsistency

### DIFF
--- a/Client/iOS/NSLogger.swift
+++ b/Client/iOS/NSLogger.swift
@@ -35,6 +35,7 @@
  */
 
 import Foundation
+import NSLogger
 
 #if os(iOS) || os(tvOS)
 

--- a/Client/iOS/NSLoggerSwift.h
+++ b/Client/iOS/NSLoggerSwift.h
@@ -1,0 +1,43 @@
+/*
+ * NSLoggerSwift.h
+ *
+ * version 1.8.3 8-MAY-2017
+ *
+ * Part of NSLogger (client side)
+ * https://github.com/fpillet/NSLogger
+ *
+ * BSD license follows (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Copyright (c) 2010-2016 Florent Pillet All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of  source code  must retain  the above  copyright notice,
+ * this list of  conditions and the following  disclaimer. Redistributions in
+ * binary  form must  reproduce  the  above copyright  notice,  this list  of
+ * conditions and the following disclaimer  in the documentation and/or other
+ * materials  provided with  the distribution.  Neither the  name of  Florent
+ * Pillet nor the names of its contributors may be used to endorse or promote
+ * products  derived  from  this  software  without  specific  prior  written
+ * permission.  THIS  SOFTWARE  IS  PROVIDED BY  THE  COPYRIGHT  HOLDERS  AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A  PARTICULAR PURPOSE  ARE DISCLAIMED.  IN  NO EVENT  SHALL THE  COPYRIGHT
+ * HOLDER OR  CONTRIBUTORS BE  LIABLE FOR  ANY DIRECT,  INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY,  OR CONSEQUENTIAL DAMAGES (INCLUDING,  BUT NOT LIMITED
+ * TO, PROCUREMENT  OF SUBSTITUTE GOODS  OR SERVICES;  LOSS OF USE,  DATA, OR
+ * PROFITS; OR  BUSINESS INTERRUPTION)  HOWEVER CAUSED AND  ON ANY  THEORY OF
+ * LIABILITY,  WHETHER  IN CONTRACT,  STRICT  LIABILITY,  OR TORT  (INCLUDING
+ * NEGLIGENCE  OR OTHERWISE)  ARISING  IN ANY  WAY  OUT OF  THE  USE OF  THIS
+ * SOFTWARE,   EVEN  IF   ADVISED  OF   THE  POSSIBILITY   OF  SUCH   DAMAGE.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for LoggerSwift.
+FOUNDATION_EXPORT double LoggerSwiftVersionNumber;
+
+//! Project version string for LoggerSwift.
+FOUNDATION_EXPORT const unsigned char LoggerSwiftVersionString[];

--- a/NSLogger.xcodeproj/project.pbxproj
+++ b/NSLogger.xcodeproj/project.pbxproj
@@ -8,9 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		123F1BCB1F7E8EC9008F260C /* NSLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAAD0F961C4BE27B0042313D /* NSLogger.framework */; };
-		3D0EE4B31EC1241100D0FA63 /* LoggerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = DAAD0FAA1C4BE55F0042313D /* LoggerClient.m */; };
-		3D0EE4B61EC1241100D0FA63 /* LoggerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAD0FA91C4BE55F0042313D /* LoggerClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D0EE4B71EC1241100D0FA63 /* NSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAD0FAC1C4BE55F0042313D /* NSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		123F1BCD1F7E994C008F260C /* NSLoggerSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 123F1BCC1F7E994C008F260C /* NSLoggerSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D0EE4DD1EC1255A00D0FA63 /* NSLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0EE4DC1EC1255A00D0FA63 /* NSLogger.swift */; };
 		DAAD0FAD1C4BE55F0042313D /* LoggerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAD0FA91C4BE55F0042313D /* LoggerClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAAD0FAE1C4BE55F0042313D /* LoggerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = DAAD0FAA1C4BE55F0042313D /* LoggerClient.m */; };
@@ -18,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		123F1BCC1F7E994C008F260C /* NSLoggerSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSLoggerSwift.h; path = Client/iOS/NSLoggerSwift.h; sourceTree = SOURCE_ROOT; };
 		3D0EE4BC1EC1241100D0FA63 /* NSLoggerSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSLoggerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0EE4DC1EC1255A00D0FA63 /* NSLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSLogger.swift; path = Client/iOS/NSLogger.swift; sourceTree = SOURCE_ROOT; };
 		DAAD0F961C4BE27B0042313D /* NSLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +76,7 @@
 				DAAD0FA91C4BE55F0042313D /* LoggerClient.h */,
 				DAAD0FAA1C4BE55F0042313D /* LoggerClient.m */,
 				DAAD0FAC1C4BE55F0042313D /* NSLogger.h */,
+				123F1BCC1F7E994C008F260C /* NSLoggerSwift.h */,
 				3D0EE4DC1EC1255A00D0FA63 /* NSLogger.swift */,
 				DAAD0F9B1C4BE27B0042313D /* Info.plist */,
 			);
@@ -90,8 +90,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D0EE4B61EC1241100D0FA63 /* LoggerClient.h in Headers */,
-				3D0EE4B71EC1241100D0FA63 /* NSLogger.h in Headers */,
+				123F1BCD1F7E994C008F260C /* NSLoggerSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -203,7 +202,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3D0EE4DD1EC1255A00D0FA63 /* NSLogger.swift in Sources */,
-				3D0EE4B31EC1241100D0FA63 /* LoggerClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NSLogger.xcodeproj/project.pbxproj
+++ b/NSLogger.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		123F1BCB1F7E8EC9008F260C /* NSLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAAD0F961C4BE27B0042313D /* NSLogger.framework */; };
 		3D0EE4B31EC1241100D0FA63 /* LoggerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = DAAD0FAA1C4BE55F0042313D /* LoggerClient.m */; };
 		3D0EE4B61EC1241100D0FA63 /* LoggerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAD0FA91C4BE55F0042313D /* LoggerClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D0EE4B71EC1241100D0FA63 /* NSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAD0FAC1C4BE55F0042313D /* NSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -17,7 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3D0EE4BC1EC1241100D0FA63 /* NSLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D0EE4BC1EC1241100D0FA63 /* NSLoggerSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSLoggerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D0EE4DC1EC1255A00D0FA63 /* NSLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSLogger.swift; path = Client/iOS/NSLogger.swift; sourceTree = SOURCE_ROOT; };
 		DAAD0F961C4BE27B0042313D /* NSLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NSLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAAD0F9B1C4BE27B0042313D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -31,6 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				123F1BCB1F7E8EC9008F260C /* NSLogger.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -44,11 +46,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		123F1BCA1F7E8EC9008F260C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DAAD0F8C1C4BE27B0042313D = {
 			isa = PBXGroup;
 			children = (
 				DAAD0F981C4BE27B0042313D /* NSLogger */,
 				DAAD0F971C4BE27B0042313D /* Products */,
+				123F1BCA1F7E8EC9008F260C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -56,7 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				DAAD0F961C4BE27B0042313D /* NSLogger.framework */,
-				3D0EE4BC1EC1241100D0FA63 /* NSLogger.framework */,
+				3D0EE4BC1EC1241100D0FA63 /* NSLoggerSwift.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -112,7 +122,7 @@
 			);
 			name = NSLoggerSwift;
 			productName = NSLogger;
-			productReference = 3D0EE4BC1EC1241100D0FA63 /* NSLogger.framework */;
+			productReference = 3D0EE4BC1EC1241100D0FA63 /* NSLoggerSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		DAAD0F951C4BE27B0042313D /* NSLogger */ = {
@@ -211,12 +221,16 @@
 		3D0EE4BA1EC1241100D0FA63 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
 			};
 			name = Debug;
 		};
 		3D0EE4BB1EC1241100D0FA63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
 			};
 			name = Release;
 		};

--- a/NSLogger.xcodeproj/xcshareddata/xcschemes/NSLoggerSwift.xcscheme
+++ b/NSLogger.xcodeproj/xcshareddata/xcschemes/NSLoggerSwift.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3D0EE4B11EC1241100D0FA63"
-               BuildableName = "NSLogger.framework"
+               BuildableName = "NSLoggerSwift.framework"
                BlueprintName = "NSLoggerSwift"
                ReferencedContainer = "container:NSLogger.xcodeproj">
             </BuildableReference>
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -46,7 +48,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3D0EE4B11EC1241100D0FA63"
-            BuildableName = "NSLogger.framework"
+            BuildableName = "NSLoggerSwift.framework"
             BlueprintName = "NSLoggerSwift"
             ReferencedContainer = "container:NSLogger.xcodeproj">
          </BuildableReference>
@@ -64,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3D0EE4B11EC1241100D0FA63"
-            BuildableName = "NSLogger.framework"
+            BuildableName = "NSLoggerSwift.framework"
             BlueprintName = "NSLoggerSwift"
             ReferencedContainer = "container:NSLogger.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
Whats here:
* `NSLoggerSwift` is now its own full fledged Product (`NSLogger` as a linked dependency) With its own Product Name
* `NSLoggerSwift` no longer builds `NSLogger` files.
* Now when the project is built users have a choice between NSLogger and/or NSLoggerSwift products.


Why:
* Carthage builds could (and did) sometimes build NSLoggerSwift over the top of NSLogger because they shared the same product name
* Closes https://github.com/fpillet/NSLogger/issues/234


