### PR TITLE
Changes bundle identifier for NSLoggerSwift target

### DIFF
--- a/NSLogger.xcodeproj/project.pbxproj
+++ b/NSLogger.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		3D0EE4BA1EC1241100D0FA63 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = com.florentpillet.NSLoggerSwift;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
 			};
@@ -227,6 +228,7 @@
 		3D0EE4BB1EC1241100D0FA63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = com.florentpillet.NSLoggerSwift;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
 			};


### PR DESCRIPTION
When using the NSLoggerSwift framework within my project (built with Carthage) together with the NSLogger framework (since NSLoggerSwift needs it) I got the following error when building and running my app:

"This application or a bundle it contains has the same bundle identifier as this application or another bundle that it contains. Bundle identifiers must be unique."

This was because the bundle identifier for both the NSLogger and NSLoggerSwift targets were identical, this pull request fixes that.