### PR TITLE
Support deprecation of swift 3 compatibility

### DIFF
--- a/Client/iOS/NSLogger.swift
+++ b/Client/iOS/NSLogger.swift
@@ -107,9 +107,11 @@ public final class Logger {
         #elseif os(OSX)
           guard let tiff = image.tiffRepresentation,
             let bitmapRep = NSBitmapImageRep(data: tiff) else { return nil }
-
+        #if swift(>=4.0)
           let imageData = bitmapRep.representation(using: .png, properties: [:])
-
+        #else
+          let imageData = bitmapRep.representation(using: .PNG, properties: [:])
+        #endif
           guard let data = imageData  else { return nil }
           return (data, Int(image.size.width), Int(image.size.height))
         #else

--- a/NSLogger.xcodeproj/project.pbxproj
+++ b/NSLogger.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 				TargetAttributes = {
 					3D0EE4B11EC1241100D0FA63 = {
 						DevelopmentTeam = 8R58U9EQLP;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0930;
 					};
 					DAAD0F951C4BE27B0042313D = {
 						CreatedOnToolsVersion = 7.2;
@@ -223,6 +223,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.florentpillet.NSLoggerSwift;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -232,6 +234,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.florentpillet.NSLoggerSwift;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)Swift";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Fixes `'PNG' has been renamed to 'png'` compiling under newer versions of Xcode for a macOS target..