### PR TITLE
Fix Carthage installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -125,13 +125,6 @@ Depending on the framework you choose, your code will need to `import NSLogger` 
 github "fpillet/NSLogger"
 ```
 
-**or**
-
-```
-github "fpillet/NSLoggerSwift"
-```
-
-
 Then run:
 
 ```shell


### PR DESCRIPTION
There is no repository `fpillet/NSLoggerSwift`
This fixes #264