### PR TITLE
Fix for file compatibility issue caused by migration to ARC.

### DIFF
--- a/Desktop/Classes/LoggerConnection.m
+++ b/Desktop/Classes/LoggerConnection.m
@@ -332,7 +332,16 @@ char sConnectionAssociatedObjectKey = 1;
 	if ((self = [super init]) != nil)
 	{
 		_clientName = [aDecoder decodeObjectForKey:@"_clientName"];
+		// When the code was converted to ARC, some of the keys have changed.
+		// In order to be backward compatible, we also need to check if the coder
+		// is using the old keys.
+		if (_clientName == nil)
+			_clientName = [aDecoder decodeObjectForKey:@"clientName"];
+
 		_clientVersion = [aDecoder decodeObjectForKey:@"_clientVersion"];
+		if (_clientVersion == nil)
+			_clientVersion = [aDecoder decodeObjectForKey:@"clientVersion"];
+
 		_clientOSName = [aDecoder decodeObjectForKey:@"clientOSName"];
 		_clientOSVersion = [aDecoder decodeObjectForKey:@"clientOSVersion"];
 		_clientDevice = [aDecoder decodeObjectForKey:@"clientDevice"];
@@ -340,12 +349,18 @@ char sConnectionAssociatedObjectKey = 1;
 		_parentIndexesStack = [aDecoder decodeObjectForKey:@"parentIndexes"];
 		_filenames = [aDecoder decodeObjectForKey:@"_filenames"];
 		if (_filenames == nil)
+			_filenames = [aDecoder decodeObjectForKey:@"filenames"];
+		if (_filenames == nil)
 			_filenames = [[NSMutableSet alloc] init];
 		_functionNames = [aDecoder decodeObjectForKey:@"_functionNames"];
+		if (_functionNames == nil)
+			_functionNames = [aDecoder decodeObjectForKey:@"functionNames"];
 		if (_functionNames == nil)
 			_functionNames = [[NSMutableSet alloc] init];
 		objc_setAssociatedObject(aDecoder, &sConnectionAssociatedObjectKey, self, OBJC_ASSOCIATION_ASSIGN);
 		_messages = [aDecoder decodeObjectForKey:@"_messages"];
+		if (_messages == nil)
+			_messages = [aDecoder decodeObjectForKey:@"messages"];
 		_reconnectionCount = [aDecoder decodeIntForKey:@"reconnectionCount"];
 		_restoredFromSave = YES;
 		


### PR DESCRIPTION
When the code was converted from MRC to ARC, the keys that were used in `initWithCoder` from `LoggerConnection` have changed. That was causing older `.nsloggerdata` exported by older NSLogger versions to not be compatible with the newer version.

The fix is to fallback on older keys if the new keys return `nil`.