### PR TITLE
NSLoggerViewer: prevent new connections from creating multiple windows

### DIFF
--- a/Desktop/Classes/LoggerTransport.m
+++ b/Desktop/Classes/LoggerTransport.m
@@ -73,6 +73,9 @@
 	// make a new document for a connection (it is considered live once we have received
 	// the ClientInfo message) or reuse an existing document if this is a reconnection
 	dispatch_async(dispatch_get_main_queue(), ^{
+        // Wait to receive a ClientInfo with all metadata before attempting to attach
+        if (aConnection.clientOSName == nil) return;
+        
 		if (!aConnection.attachedToWindow)
 			[(LoggerAppDelegate *)[NSApp delegate] newConnection:aConnection fromTransport:self];
 	});


### PR DESCRIPTION
This happens in our project because the first ClientInfo message received
only contains the application name and version, but not the OS details.
Afterwards a second ClientInfo is received with the full metadata set,
but by that time the connection has already been attached to a new
window.

I'm not sure if this is something we could fix in our project by
initializing NSLogger differently.