### PR TITLE
remove broken BuddyBuild status

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,6 @@
 
 # NSLogger
 
-[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5914439af77e0000015a7b82&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5914439af77e0000015a7b82/build/latest?branch=master)
 [![Pod Version](http://img.shields.io/cocoapods/v/NSLogger.svg?style=flat)](http://cocoadocs.org/docsets/NSLogger/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Pod Platform](http://img.shields.io/cocoapods/p/NSLogger.svg?style=flat)](http://cocoadocs.org/docsets/NSLogger/)


### PR DESCRIPTION
[@**Apple**](https://github.com/apple) discontinued ~[@**BuddyBuild**](https://github.com/BuddyBuild)~ services in 2021[^1]

---
[^1]: _MacRumors_ [Canadian Startup Buddybuild Shutting Down Following 2018 Apple&nbsp;Acquisition](https://macrumors.com/2021/03/01/buddybuild-closing-after-apple-buyout) ([archive](https://web.archive.org/web/0/macrumors.com/2021/03/01/buddybuild-closing-after-apple-buyout))
