### PR TITLE
Add missing imports for AppKit or Foundation in several header files.

### DIFF
--- a/Desktop/Classes/LoggerDocumentController.h
+++ b/Desktop/Classes/LoggerDocumentController.h
@@ -29,6 +29,8 @@
  *
  */
 
+#import <AppKit/AppKit.h>
+
 @interface LoggerDocumentController : NSDocumentController
 
 @end

--- a/Desktop/Classes/LoggerSplitView.h
+++ b/Desktop/Classes/LoggerSplitView.h
@@ -28,6 +28,8 @@
  * SOFTWARE,   EVEN  IF   ADVISED  OF   THE  POSSIBILITY   OF  SUCH   DAMAGE.
  * 
  */
+
+#import <AppKit/AppKit.h>
 #import "BWToolkitFramework.h"
 
 @interface LoggerSplitView : NSSplitView

--- a/Desktop/Classes/LoggerStatusWindowController.h
+++ b/Desktop/Classes/LoggerStatusWindowController.h
@@ -29,6 +29,8 @@
  * 
  */
 
+#import <AppKit/AppKit.h>
+
 @class LoggerTransportStatusCell;
 
 @interface LoggerStatusWindowController : NSWindowController <NSTableViewDelegate, NSTableViewDataSource>

--- a/Desktop/Classes/LoggerTCPConnection.m
+++ b/Desktop/Classes/LoggerTCPConnection.m
@@ -27,7 +27,9 @@
  * NEGLIGENCE  OR OTHERWISE)  ARISING  IN ANY  WAY  OUT OF  THE  USE OF  THIS
  * SOFTWARE,   EVEN  IF   ADVISED  OF   THE  POSSIBILITY   OF  SUCH   DAMAGE.
  * 
- */#import "LoggerTCPConnection.h"
+ */
+
+#import "LoggerTCPConnection.h"
 
 #define TMP_BUF_SIZE	((size_t)32767)
 

--- a/Desktop/Classes/LoggerTableView.h
+++ b/Desktop/Classes/LoggerTableView.h
@@ -29,6 +29,8 @@
  * 
  */
 
+#import <AppKit/AppKit.h>
+
 @interface LoggerTableView : NSTableView
 
 @property (nonatomic, retain) NSTrackingArea *tableTrackingArea;

--- a/Desktop/Classes/LoggerTransportStatusCell.h
+++ b/Desktop/Classes/LoggerTransportStatusCell.h
@@ -29,6 +29,8 @@
  * 
  */
 
+#import <AppKit/AppKit.h>
+
 @interface LoggerTransportStatusCell : NSCell
 {
 }

--- a/Desktop/Classes/ValueTransformers.h
+++ b/Desktop/Classes/ValueTransformers.h
@@ -29,6 +29,8 @@
  * 
  */
 
+#import <Foundation/Foundation.h>
+
 // Value transformer for bindings that returns YES when the filter selection can be deleted
 // (to enable the Delete button in the filters list)
 @interface CanFilterSelectionBeDeletedValueTransformer : NSValueTransformer


### PR DESCRIPTION
Even if the compiler figures out these missing imports when building with Xcode, other tools like Bazel produce errors.