### PR TITLE
Do not convert C strings to UTF-8

### DIFF
--- a/Client/iOS/LoggerClient.m
+++ b/Client/iOS/LoggerClient.m
@@ -2405,34 +2405,17 @@ static void LoggerMessageAddCString(CFMutableDataRef data, const char *aString, 
 	if (aString == NULL || *aString == 0)
 		return;
 	
-	// convert to UTF-8
-	int len = (int)strlen(aString);
-	uint8_t *buf = malloc((size_t)(2 * len));
-	if (buf != NULL)
+	int n = (int)strlen(aString);
+	if (n)
 	{
-		int i, n = 0;
-		for (i = 0; i < len; i++)
+		uint8_t *p = LoggerMessagePrepareForPart(data, (uint32_t)n+6);
+		if (p != NULL)
 		{
-			uint8_t c = (uint8_t)(*aString++);
-			if (c < 0x80)
-				buf[n++] = c;
-			else {
-				buf[n++] = 0xC0 | (c >> 6);
-				buf[n++] = (c & 0x6F) | 0x80;
-			}
+			*p++ = (uint8_t)key;
+			*p++ = (uint8_t)PART_TYPE_STRING;
+			WRITE_MISALIGNED_INT32(p, n)
+			memcpy(p + 4, aString, (size_t)n);
 		}
-		if (n)
-		{
-			uint8_t *p = LoggerMessagePrepareForPart(data, (uint32_t)n+6);
-			if (p != NULL)
-			{
-				*p++ = (uint8_t)key;
-				*p++ = (uint8_t)PART_TYPE_STRING;
-				WRITE_MISALIGNED_INT32(p, n)
-				memcpy(p + 4, buf, (size_t)n);
-			}
-		}
-		free(buf);
 	}
 }
 


### PR DESCRIPTION
Today, the `__FILE__` predefined macro is already encoded in UTF-8. Maybe that was not the case in 2010 when the file/line/function support was introduced in commit d43596b5753bd3d96886fd6d9cc61283cbd9edae.

Here are screenshots of what happens before and after this commit using the following code:

```c
LogMessageRawToF(logger, __FILE__, __LINE__, __PRETTY_FUNCTION__, NULL, 2, @"👋 Hello, world!");
```

Before this commit, the file is not displayed because of the double UTF-8 encoding:

<img width="1442" alt="Screenshot before fixing the encoding issue" src="https://github.com/fpillet/NSLogger/assets/51363/d84249cc-4df8-4a84-9c54-5cef42b10b3b">

After this commit, the file is properly displayed:

<img width="1442" alt="Screenshot after fixing the encoding issue" src="https://github.com/fpillet/NSLogger/assets/51363/ce35cd4c-ea01-412e-8666-8e63b5c27796">